### PR TITLE
Add feedback, accessibility statement and privacy policy links

### DIFF
--- a/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
+++ b/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
@@ -38,19 +38,19 @@ class EkirjastoDocumentStoreConfiguration : DocumentConfigurationServiceType {
     remoteURI = URI.create("https://lib.e-kirjasto.fi/palaute")
   )
 
+  override val acknowledgements: DocumentConfiguration? =
+    null
+
   // If you are adding or trying to modify an accessibilityStatement field be sure to have a look
   // at the lines below as well as the class documentation.
   val accessibilityStatement: DocumentConfiguration? = null
   // A better name for this would be "accessibilityStatement" or "accessibilityReport".
   // As to why this is weirdly named, check the long explanation given in the class documentation.
-  override val acknowledgements: DocumentConfiguration? =
+  override val eula: DocumentConfiguration? =
     DocumentConfiguration(
       name = null,
       remoteURI = URI.create("https://www.kansalliskirjasto.fi/fi/e-kirjasto/e-kirjaston-saavutettavuusseloste")
     )
-
-  override val eula: DocumentConfiguration? =
-    null
 
   override val licenses: DocumentConfiguration? =
     null

--- a/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
+++ b/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
@@ -2,17 +2,52 @@ package fi.kansalliskirjasto.ekirjasto
 
 import org.librarysimplified.documents.DocumentConfiguration
 import org.librarysimplified.documents.DocumentConfigurationServiceType
+import java.net.URI
 
+/* Note that we are doing a "translation hack" where we reuse these link slots instead of changing
+ * the original code. This solution assumes that all the strings will be translated from the
+ * "base" language into English, Finnish and Swedish later. So while the base version will say
+ * "About" the English version will say "Feedback".
+ *
+ * A more robust solution might be to add overrides where the necessary fields are added and
+ * properly named, but deadline pressures being what they are this will have to suffice.
+ *
+ * All our current link sites contain a separate language selector. Later when we get the user
+ * language from somewhere we could include the language in the link as a URL param or something.
+ * Alternatively if the forms themselves are embedded in the app then we should be already be able
+ * to get the language from somewhere (which isn't possible as of this writing).
+ *
+ * The "real" names for the fields have been listed above the fields so that if you are trying to
+ * find these fields in the future you might have more success.
+ */
 class EkirjastoDocumentStoreConfiguration : DocumentConfigurationServiceType {
-
   override val privacyPolicy: DocumentConfiguration? =
-    null
+  DocumentConfiguration(
+    name = null,
+    remoteURI = URI.create("https://www.kansalliskirjasto.fi/fi/e-kirjasto/e-kirjaston-tietosuoja-ja-rekisteriseloste")
+  )
 
+  // If you are adding or trying to modify a feedback field, please have a look at the lines below
+  // as well as the class documentation.
+  val feedback: DocumentConfiguration? = null
+  // A better name for this would be "feedback".
+  // As to why this is weirdly named, check the long explanation given in the class documentation.
   override val about: DocumentConfiguration? =
-    null
+  DocumentConfiguration(
+    name = null,
+    remoteURI = URI.create("https://lib.e-kirjasto.fi/palaute")
+  )
 
+  // If you are adding or trying to modify an accessibilityStatement field be sure to have a look
+  // at the lines below as well as the class documentation.
+  val accessibilityStatement: DocumentConfiguration? = null
+  // A better name for this would be "accessibilityStatement" or "accessibilityReport".
+  // As to why this is weirdly named, check the long explanation given in the class documentation.
   override val acknowledgements: DocumentConfiguration? =
-    null
+    DocumentConfiguration(
+      name = null,
+      remoteURI = URI.create("https://www.kansalliskirjasto.fi/fi/e-kirjasto/e-kirjaston-saavutettavuusseloste")
+    )
 
   override val eula: DocumentConfiguration? =
     null

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDocumentViewerFragment.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDocumentViewerFragment.kt
@@ -41,6 +41,11 @@ class SettingsDocumentViewerFragment : Fragment() {
         webView.webChromeClient = WebChromeClient()
         webView.settings.allowFileAccess = true
 
+        // Beware that this line is a potential XSS vulnerability. The sites displayed are all
+        // assumed to be benign enough for this to be OK and if the worst should happen the certs
+        // can be revoked and this has tested to work as expected.
+        webView.settings.javaScriptEnabled = true
+
         WebViewUtilities.setForcedDark(webView.settings, resources.configuration)
 
         webView.loadUrl(url!!)

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDocumentViewerFragment.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDocumentViewerFragment.kt
@@ -39,7 +39,7 @@ class SettingsDocumentViewerFragment : Fragment() {
       binding.documentViewerWebView.let { webView ->
         webView.webViewClient = WebViewClient()
         webView.webChromeClient = WebChromeClient()
-        webView.settings.allowFileAccess = true
+        webView.settings.allowFileAccess = false
 
         // Beware that this line is a potential XSS vulnerability. The sites displayed are all
         // assumed to be benign enough for this to be OK and if the worst should happen the certs


### PR DESCRIPTION
**What's this do?**

Adds links that are displayed in the settings page. We do this in a slightly weird way so we don't have to override everything separately (but that will probably be the way to do things in the long run so we might get back to this after our first release).

Also enables JavaScript in WebViews so the pages actually work. This presents a small but probably acceptable XSS risk.

**Why are we doing this? (w/ JIRA link if applicable)**

Because people need to be able to access the documents somehow. They also need to be able to choose the language, and MS forms seems to require JS to work, so it has to be enabled.

**How should this be tested? / Do these changes have associated tests?**

Sending feedback via the link. Making sure the documents are accessible and readable in all languages.

**Dependencies for merging? Releasing to production?**

None

**Have you updated the changelog?**

No

**Has the application documentation been updated for these changes?**

No

**Did someone actually run this code to verify it works?**

Yes.