### PR TITLE
Deactivate "change accounts" menu without hiding the action bar logo

### DIFF
--- a/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoBuildConfigurationService.kt
+++ b/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoBuildConfigurationService.kt
@@ -39,6 +39,8 @@ class EkirjastoBuildConfigurationService : BuildConfigurationServiceType {
   override val allowExternalReaderLinks: Boolean
     get() = false
   override val showChangeAccountsUi: Boolean
+    get() = false
+  override val showActionBarLogo: Boolean
     get() = true
   override val showAgeGateUi: Boolean
     get() = true

--- a/simplified-app-palace/src/main/java/org/thepalaceproject/palace/PalaceBuildConfigurationService.kt
+++ b/simplified-app-palace/src/main/java/org/thepalaceproject/palace/PalaceBuildConfigurationService.kt
@@ -42,6 +42,8 @@ class PalaceBuildConfigurationService : BuildConfigurationServiceType {
     get() = false
   override val showChangeAccountsUi: Boolean
     get() = true
+  override val showActionBarLogo: Boolean
+    get() = false
   override val showAgeGateUi: Boolean
     get() = true
   override val brandingAppIcon: Int

--- a/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationAccountsType.kt
+++ b/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationAccountsType.kt
@@ -37,6 +37,14 @@ interface BuildConfigurationAccountsType {
   val showChangeAccountsUi: Boolean
 
   /**
+   * If `showChangeAccountsUi` is set to `false`, setting this to true will
+   * still show the logo in the action bar. If `showChangeAccountsUi` is true,
+   * this setting will have no effect.
+   */
+
+  val showActionBarLogo: Boolean
+
+  /**
    * If set to `true`, users will be show age verification prompts and status on
    * the accounts screen.
    */

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedFragment.kt
@@ -599,6 +599,19 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
       }
 
       /*
+       * If the change accounts UI is disabled, check if logo should be shown.
+       */
+      if (this.configurationService.showActionBarLogo) {
+        // Show the logo, but don't make it act like a button
+        actionBar.setLogo(this.configurationService.brandingAppIcon)
+        actionBar.setDisplayHomeAsUpEnabled(false)
+        this.toolbar.setLogoOnClickListener {
+          // Do nothing
+        }
+        return
+      }
+
+      /*
        * Otherwise, show nothing.
        */
 


### PR DESCRIPTION
The app has a config option called `showChangeAccountsUi`, which is used to enable/disable the logo in the action bar, which is used as a button to open the "change accounts" menu.

In E-kirjasto, we want to disable that menu, but still show the logo. To do this, a new build config option `showActionBarLogo` was added (this new option is only in effect if `showChangeAccountsUi` is false).

If `showChangeAccountsUi` is false and `showActionBarLogo` is true, the logo is shown, but does not act as a button. These settings are now the default in E-kirjasto.

This code could even be contributed into The Palace Project, but no plans to do that for now.

Issue: SIMPLYE-196

**What's this do?**
Disable "Change accounts" menu that opens by pressing the logo in the top-left of the app.

**Why are we doing this? (w/ JIRA link if applicable)**
Jira issue: SIMPLYE-196

**How should this be tested? / Do these changes have associated tests?**
Manual testing.

**Dependencies for merging? Releasing to production?**
Could optionally be merged back upstream (to the Palace Project).

**Have you updated the changelog?**

**Has the application documentation been updated for these changes?**
Added docstrings to the code, not sure if documentation is already generated from those.

**Did someone actually run this code to verify it works?**
Yes, tested.
