### PR TITLE
Settings links simple version

### DIFF
--- a/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
+++ b/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
@@ -2,11 +2,27 @@ package fi.kansalliskirjasto.ekirjasto
 
 import org.librarysimplified.documents.DocumentConfiguration
 import org.librarysimplified.documents.DocumentConfigurationServiceType
+import java.net.URI
 
 class EkirjastoDocumentStoreConfiguration : DocumentConfigurationServiceType {
 
   override val privacyPolicy: DocumentConfiguration? =
-    null
+    DocumentConfiguration(
+      name = null,
+      remoteURI = URI.create("https://www.kansalliskirjasto.fi/fi/e-kirjasto/e-kirjaston-tietosuoja-ja-rekisteriseloste")
+    )
+
+  override val feedback: DocumentConfiguration? =
+    DocumentConfiguration(
+      name = null,
+      remoteURI = URI.create("https://lib.e-kirjasto.fi/palaute")
+    )
+
+  override val accessibilityStatement: DocumentConfiguration? =
+    DocumentConfiguration(
+      name = null,
+      remoteURI = URI.create("https://www.kansalliskirjasto.fi/fi/e-kirjasto/e-kirjaston-saavutettavuusseloste")
+    )
 
   override val about: DocumentConfiguration? =
     null

--- a/simplified-app-palace/src/main/java/org/thepalaceproject/palace/PalaceDocumentStoreConfiguration.kt
+++ b/simplified-app-palace/src/main/java/org/thepalaceproject/palace/PalaceDocumentStoreConfiguration.kt
@@ -12,6 +12,12 @@ class PalaceDocumentStoreConfiguration : DocumentConfigurationServiceType {
       remoteURI = URI.create("https://legal.palaceproject.io/Privacy%20Policy.html")
     )
 
+  override val feedback: DocumentConfiguration? =
+    null
+
+  override val accessibilityStatement: DocumentConfiguration? =
+    null
+
   override val about: DocumentConfiguration? =
     DocumentConfiguration(
       name = null,

--- a/simplified-documents/src/main/java/org/librarysimplified/documents/DocumentConfigurationServiceType.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/DocumentConfigurationServiceType.kt
@@ -13,6 +13,16 @@ interface DocumentConfigurationServiceType {
   val privacyPolicy: DocumentConfiguration?
 
   /**
+   * @return The application feedback form, if any.
+   */
+  val feedback: DocumentConfiguration?
+
+  /**
+   * @return The accessibility statement, if any.
+   */
+  val accessibilityStatement: DocumentConfiguration?
+
+  /**
    * @return The application acknowledgements, if any.
    */
 

--- a/simplified-documents/src/main/java/org/librarysimplified/documents/DocumentStoreType.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/DocumentStoreType.kt
@@ -12,6 +12,18 @@ interface DocumentStoreType {
   val privacyPolicy: DocumentType?
 
   /**
+   * @return The application feedback form, if any.
+   */
+
+  val feedback: DocumentType?
+
+  /**
+   * @return The application accessibility statement, if any.
+   */
+
+  val accessibilityStatement: DocumentType?
+
+  /**
    * @return The application acknowledgements, if any.
    */
 

--- a/simplified-documents/src/main/java/org/librarysimplified/documents/internal/DocumentStore.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/internal/DocumentStore.kt
@@ -19,6 +19,8 @@ internal class DocumentStore private constructor(
   override val eula: EULAType?,
   override val licenses: DocumentType?,
   override val privacyPolicy: DocumentType?,
+  override val feedback: DocumentType?,
+  override val accessibilityStatement: DocumentType?,
   override val faq: DocumentType?
 ) : DocumentStoreType {
 
@@ -73,6 +75,23 @@ internal class DocumentStore private constructor(
           config = configuration.privacyPolicy
         )
 
+      val feedback =
+        this.documentForMaybe(
+          assetManager = assetManager,
+          http = http,
+          baseDirectory = baseDirectory,
+          config = configuration.feedback
+        )
+
+      val accessibilityStatement =
+        this.documentForMaybe(
+          assetManager = assetManager,
+          http = http,
+          baseDirectory = baseDirectory,
+          config = configuration.accessibilityStatement
+        )
+
+
       val faq =
         this.documentForMaybe(
           assetManager = assetManager,
@@ -87,6 +106,8 @@ internal class DocumentStore private constructor(
         eula = eula,
         licenses = licenses,
         privacyPolicy = privacyPolicy,
+        feedback = feedback,
+        accessibilityStatement = accessibilityStatement,
         faq = faq
       )
     }

--- a/simplified-documents/src/main/java/org/librarysimplified/documents/internal/EmptyDocumentStore.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/internal/EmptyDocumentStore.kt
@@ -10,6 +10,10 @@ import org.librarysimplified.documents.EULAType
 internal object EmptyDocumentStore : DocumentStoreType {
   override val privacyPolicy: DocumentType? =
     null
+  override val feedback: DocumentType? =
+    null
+  override val accessibilityStatement: DocumentType? =
+    null
   override val about: DocumentType? =
     null
   override val acknowledgements: DocumentType? =

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
@@ -506,6 +506,16 @@ internal class MainFragmentListenerDelegate(
         this.openSettingsPrivacy(event.title, event.url)
         state
       }
+
+      is SettingsMainEvent.OpenFeedback -> {
+        this.openSettingsFeedback(event.title, event.url)
+        state
+      }
+
+      is SettingsMainEvent.OpenAccessibilityStatement -> {
+        this.openSettingsAccessibilityStatement(event.title, event.url)
+        state
+      }
     }
   }
 
@@ -602,6 +612,22 @@ internal class MainFragmentListenerDelegate(
       tab = org.librarysimplified.ui.tabs.R.id.tabSettings
     )
   }
+
+  private fun openSettingsFeedback(title: String, url: String) {
+    this.navigator.addFragment(
+      fragment = SettingsDocumentViewerFragment.create(title, url),
+      tab = org.librarysimplified.ui.tabs.R.id.tabSettings
+    )
+  }
+
+  private fun openSettingsAccessibilityStatement(title: String, url: String) {
+    this.navigator.addFragment(
+      fragment = SettingsDocumentViewerFragment.create(title, url),
+      tab = org.librarysimplified.ui.tabs.R.id.tabSettings
+    )
+  }
+
+
 
   private fun openSettingsVersion() {
     this.navigator.addFragment(

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDocumentViewerFragment.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDocumentViewerFragment.kt
@@ -39,7 +39,13 @@ class SettingsDocumentViewerFragment : Fragment() {
       binding.documentViewerWebView.let { webView ->
         webView.webViewClient = WebViewClient()
         webView.webChromeClient = WebChromeClient()
-        webView.settings.allowFileAccess = true
+
+        // Beware that this line is a potential XSS vulnerability. The sites displayed are all
+        // assumed to be benign enough for this to be OK and if the worst should happen the certs
+        // can be revoked and this has been tested to work as expected.
+        webView.settings.javaScriptEnabled = true
+        // Disable file access to prevent potential file theft
+        webView.settings.allowFileAccess = false
 
         WebViewUtilities.setForcedDark(webView.settings, resources.configuration)
 

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsMainEvent.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsMainEvent.kt
@@ -67,4 +67,21 @@ sealed class SettingsMainEvent {
     val title: String,
     val url: String,
   ) : SettingsMainEvent()
+
+  /**
+   * The settings screen wants to open the "Feedback" screen.
+   */
+
+  data class OpenFeedback(
+    val title: String,
+    val url: String,
+  ) : SettingsMainEvent()
+
+  /**
+   * The settings screen wants to open the "Accessibility Statement" screen.
+   */
+  data class OpenAccessibilityStatement(
+    val title: String,
+    val url: String,
+  ) : SettingsMainEvent()
 }

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsMainFragment.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsMainFragment.kt
@@ -40,6 +40,8 @@ class SettingsMainFragment : PreferenceFragmentCompat() {
   private lateinit var settingsFaq: Preference
   private lateinit var settingsLicense: Preference
   private lateinit var settingsPrivacy: Preference
+  private lateinit var settingsFeedback: Preference
+  private lateinit var settingsAccessibilityStatement: Preference
   private lateinit var settingsVersion: Preference
   private lateinit var settingsVersionCore: Preference
   private lateinit var toolbar: PalaceToolbar
@@ -62,6 +64,8 @@ class SettingsMainFragment : PreferenceFragmentCompat() {
     this.settingsFaq = this.findPreference("settingsFaq")!!
     this.settingsLicense = this.findPreference("settingsLicense")!!
     this.settingsPrivacy = this.findPreference("settingsPrivacy")!!
+    this.settingsFeedback = this.findPreference("settingsFeedback")!!
+    this.settingsAccessibilityStatement = this.findPreference("settingsAccessibilityStatement")!!
     this.settingsVersion = this.findPreference("settingsVersion")!!
     this.settingsVersionCore = this.findPreference("settingsVersionCore")!!
 
@@ -74,6 +78,8 @@ class SettingsMainFragment : PreferenceFragmentCompat() {
     this.configureFaq(this.settingsFaq)
     this.configureLicense(this.settingsLicense)
     this.configurePrivacy(this.settingsPrivacy)
+    this.configureFeedback(this.settingsFeedback)
+    this.configureAccessibilityStatement(this.settingsAccessibilityStatement)
     this.configureVersion(this.settingsVersion)
     this.configureVersionCore(this.settingsVersionCore)
   }
@@ -212,6 +218,40 @@ class SettingsMainFragment : PreferenceFragmentCompat() {
         Preference.OnPreferenceClickListener {
           this.listener.post(
             SettingsMainEvent.OpenPrivacy(
+              title = it.title.toString(),
+              url = doc.readableURL.toString()
+            )
+          )
+          true
+        }
+    }
+  }
+
+  private fun configureFeedback(preference: Preference) {
+    val doc = this.viewModel.documents.feedback
+    preference.isVisible = doc != null
+    if (doc != null) {
+      preference.onPreferenceClickListener =
+        Preference.OnPreferenceClickListener {
+          this.listener.post(
+            SettingsMainEvent.OpenFeedback(
+              title = it.title.toString(),
+              url = doc.readableURL.toString()
+            )
+          )
+          true
+        }
+    }
+  }
+
+  private fun configureAccessibilityStatement(preference: Preference) {
+    val doc = this.viewModel.documents.accessibilityStatement
+    preference.isVisible = doc != null
+    if (doc != null) {
+      preference.onPreferenceClickListener =
+        Preference.OnPreferenceClickListener {
+          this.listener.post(
+            SettingsMainEvent.OpenAccessibilityStatement(
               title = it.title.toString(),
               url = doc.readableURL.toString()
             )

--- a/simplified-ui-settings/src/main/res/values/strings.xml
+++ b/simplified-ui-settings/src/main/res/values/strings.xml
@@ -54,6 +54,10 @@
   <string name="settingsFaqSummary" />
   <string name="settingsPrivacy">Privacy Policy</string>
   <string name="settingsPrivacySummary" />
+  <string name="settingsFeedback">Feedback</string>
+  <string name="settingsFeedbackSummary" />
+  <string name="settingsAccessibilityStatement">Accessibility Statement</string>
+  <string name="settingsAccessibilityStatementSummary" />
   <string name="settingsInfo">App info</string>
   <string name="settingsLicense">Software Licenses</string>
   <string name="settingsLicenseSummary" />

--- a/simplified-ui-settings/src/main/res/xml/settings.xml
+++ b/simplified-ui-settings/src/main/res/xml/settings.xml
@@ -4,6 +4,12 @@
   xmlns:tools="http://schemas.android.com/tools">
 
   <Preference
+      android:icon="@android:drawable/ic_menu_send"
+      android:key="settingsFeedback"
+      android:summary="@string/settingsFeedbackSummary"
+      android:title="@string/settingsFeedback" />
+
+  <Preference
     android:icon="@drawable/ic_settings_account"
     android:key="settingsAccounts"
     android:summary="@string/settingsAccountsSummary"
@@ -40,6 +46,12 @@
           android:key="settingsPrivacy"
           android:summary="@string/settingsPrivacySummary"
           android:title="@string/settingsPrivacy" />
+
+    <Preference
+        android:key="settingsAccessibilityStatement"
+        android:summary="@string/settingsAccessibilityStatementSummary"
+        android:title="@string/settingsAccessibilityStatement" />
+
   </PreferenceCategory>
 
   <PreferenceCategory android:title="@string/settingsInfo">


### PR DESCRIPTION
**What's this do?**

Adds links to the settings page in a simple manner.

**Why are we doing this? (w/ JIRA link if applicable)**

Check EKIR-45 and SIMPLYE-217. Probably simpler to comprehend than the translation hack (#19).

**How should this be tested? / Do these changes have associated tests?**

Check that you can read the links in all languages and that you can send feedback through the link.

**Dependencies for merging? Releasing to production?**

No

**Have you updated the changelog?**

No

**Did someone actually run this code to verify it works?**

Yes I did and it works in the emulator.