### PR TITLE
Change layout of book page so that author is not under buttons

### DIFF
--- a/simplified-ui-catalog/src/main/res/layout/book_detail.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail.xml
@@ -77,9 +77,9 @@
                 android:layout_marginEnd="16dp"
                 android:gravity="start|bottom"
                 android:orientation="horizontal"
-                app:layout_constraintBottom_toBottomOf="@+id/bookDetailCover"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/bookDetailCover">
+                app:layout_constraintStart_toEndOf="@id/bookDetailCover"
+                app:layout_constraintTop_toBottomOf="@id/bookDetailAuthors">
 
                 <!-- These views are removed at runtime and are just present for the sake of the UI editor preview -->
 


### PR DESCRIPTION
In book_detail.xml, added a constraint between the top of the buttons and bottom of author,
because the buttons would hide the author when the name of the
book was long. Removed constraint between the bottom of the buttons and
bottom of the cover image, because the buttons would disappear or remain 
hovering over the text when the text size was scaled from settings or the 
name of the book was long. Also removed one unnecessary plus from a @id call.

To note:
These changes make it so that the placement of the buttons is not as
consistent, but they don't cover up any text. Scaling of text also works with this version, 
but with extremely long titles or big text, the page's look might not be optimal.

Ref EKIR-95