### PR TITLE
 Move reserve button to correct place

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -707,7 +707,6 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
         }
       )
     )
-    this.buttons.addView(this.buttonCreator.createButtonSpace())
     this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
 
     this.checkButtonViewCount()

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -700,14 +700,6 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
   ) {
     this.buttons.removeAllViews()
 
-    val createPreviewButton = bookPreviewStatus != BookPreviewStatus.None
-
-    if (createPreviewButton) {
-      this.buttons.addView(this.buttonCreator.createButtonSpace())
-    } else {
-      this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
-    }
-
     this.buttons.addView(
       this.buttonCreator.createReserveButton(
         onClick = {
@@ -715,21 +707,8 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
         }
       )
     )
-
-    if (createPreviewButton) {
-      this.buttons.addView(this.buttonCreator.createButtonSpace())
-      this.buttons.addView(
-        this.buttonCreator.createReadPreviewButton(
-          bookFormat = parameters.feedEntry.probableFormat,
-          onClick = {
-            viewModel.openBookPreview(parameters.feedEntry)
-          }
-        )
-      )
-      this.buttons.addView(this.buttonCreator.createButtonSpace())
-    } else {
-      this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
-    }
+    this.buttons.addView(this.buttonCreator.createButtonSpace())
+    this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
 
     this.checkButtonViewCount()
 


### PR DESCRIPTION
 Changed CatalogBookDetailFragment by removing old code
 that created empty spaces for buttons not needed in the
 project. This was done because the spaces moved the
 reserve button to an incorrect position. Added a button
 sized space to make the button not take up the whole row
 and added a small space to make it consistently sized with
 buttons in other views. 

To note:
Function onBookStatusHoldable has an unused parameter
bookPreviewStatus.

 Ref SIMPLYE-296