### PR TITLE
Remove empty button space to place cancel button correctly

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -919,7 +919,6 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
      */
 
     this.buttons.removeAllViews()
-    this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
     this.buttons.addView(
       this.buttonCreator.createCancelDownloadButton(
         onClick = {


### PR DESCRIPTION
Removed one empty button space in
onBookStatusDownloading because it
moved the cancel button to incorrect spot.
Now cancel button is positioned like other 
primary action buttons.

Ref SIMPLYE-298