### PR TITLE
Add Accept-Language header to all HTTP requests

### DIFF
--- a/simplified-main/build.gradle.kts
+++ b/simplified-main/build.gradle.kts
@@ -141,6 +141,7 @@ dependencies {
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlin.stdlib)
     implementation(libs.logback.android)
+    implementation(libs.okhttp3)
     implementation(libs.palace.audiobook.feedbooks)
     implementation(libs.palace.drm.core)
     implementation(libs.palace.http.api)

--- a/simplified-main/src/main/java/org/librarysimplified/main/CustomHTTPInterceptors.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/CustomHTTPInterceptors.kt
@@ -1,0 +1,51 @@
+package org.librarysimplified.main
+
+import android.content.Context
+import android.content.res.Resources
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.librarysimplified.http.vanilla.extensions.LSHTTPInterceptorFactoryType
+import org.slf4j.LoggerFactory
+import java.util.Locale
+import kotlin.math.max
+
+
+class CustomHTTPInterceptors {
+  class AcceptLanguageFactory : LSHTTPInterceptorFactoryType {
+    override val name: String = "org.librarysimplified.http.accept_language"
+    override val version: String = "1.0.0"
+
+    override fun createInterceptor(context: Context): Interceptor {
+      return AcceptLanguage()
+    }
+  }
+
+  class AcceptLanguage : Interceptor {
+    private val logger = LoggerFactory.getLogger(AcceptLanguage::class.java)
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+      val acceptLanguageHeader = getAcceptLanguageHeader()
+      logger.debug("Insert Accept-Language header: $acceptLanguageHeader")
+      val request = chain.request().newBuilder()
+        .addHeader("Accept-Language", acceptLanguageHeader)
+        .build()
+      return chain.proceed(request)
+    }
+
+    private fun getAcceptLanguageHeader(): String {
+      // LocaleList cannot give you an actual *list*, so convert to a string and split into a list
+      val languageTags = Resources.getSystem().configuration.locales.toLanguageTags().split(",")
+      // According to RFC2616, quality must be in the range 0-1 and have at most 3 decimal digits,
+      // so let's start at 1.000 and go down by 0.001 after every language tag
+      var quality = 1.000
+      val acceptLanguageHeader = languageTags.fold(""){ accumulator, langTag ->
+        // Java (or Kotlin here) is always so *succinct*
+        val langTagWithQ = "$langTag;q=" + String.format(Locale.ENGLISH, "%.3f", quality)
+        quality = max(0.001, quality - 0.001)
+        if (accumulator.isEmpty()) langTagWithQ else "$accumulator, $langTagWithQ"
+      }
+
+      return acceptLanguageHeader
+    }
+  }
+}

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainHTTP.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainHTTP.kt
@@ -5,6 +5,9 @@ import android.content.pm.PackageManager
 import org.librarysimplified.http.api.LSHTTPClientConfiguration
 import org.librarysimplified.http.api.LSHTTPClientType
 import org.librarysimplified.http.vanilla.LSHTTPClients
+import org.librarysimplified.http.vanilla.LSHTTPProblemReportParsers
+import org.librarysimplified.http.vanilla.extensions.LSHTTPInterceptorFactoryType
+import java.util.ServiceLoader
 import java.util.concurrent.TimeUnit
 
 object MainHTTP {
@@ -31,6 +34,10 @@ object MainHTTP {
         timeout = Pair(15L, TimeUnit.MINUTES)
       )
 
-    return LSHTTPClients().create(context, configuration)
+    // Add Accept-Language interceptor to the list of auto-discovered interceptors
+    val interceptors = ServiceLoader.load(LSHTTPInterceptorFactoryType::class.java).toList()
+      .plus(CustomHTTPInterceptors.AcceptLanguageFactory())
+
+    return LSHTTPClients(LSHTTPProblemReportParsers(), interceptors).create(context, configuration)
   }
 }


### PR DESCRIPTION
This adds an HTTP request interceptor to insert an Accept-Language header to all requests, in order for the backend to return localized strings in the OPDS feed.

The interceptor inserts all languages the user has set in their Android settings (ordered list of languages), and adds quality (`q`) values for them, so the OPDS feed strings should always get the same language as the app strings.

Tested with varying configurations of 1-5 languages defined in Android's system settings, some of which were supported by the app and some not. Works as expected, the backend returns strings in the first supported language (or English as a fallback, if none are supported).

Related issues:
- [SIMPLYE-204](https://jira.lingsoft.fi/browse/SIMPLYE-204)
- [SIMPLYE-214](https://jira.lingsoft.fi/browse/SIMPLYE-214)
- [SIMPLYE-191](https://jira.lingsoft.fi/browse/SIMPLYE-191)