### PR TITLE
Change buttons with duration icons to use PrimaryButton style

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogButtons.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogButtons.kt
@@ -133,7 +133,10 @@ class CatalogButtons(
     @StringRes res: Int,
     onClick: () -> Unit
   ): View {
-    val button = MaterialButton(this.context)
+    val button = MaterialButton(
+      ContextThemeWrapper(this.context, R.style.PrimaryButton),
+      null, R.style.PrimaryButton
+    )
     button.text = this.context.getString(res)
     button.contentDescription = this.context.getString(res)
     button.layoutParams = this.buttonLayoutParameters(true)


### PR DESCRIPTION
Changed the MaterialButton call in
CreateButtonWithDuration in CatalogButtons
so that it takes style as parameter, and gave it
the PrimaryButton style, because the buttons with
duration icons were inconsistent with other primary buttons.

To note: This makes it so that every button with a 
duration icon is automatically in the style of PrimaryButton.

Ref SIMPLYE-299
