### PR TITLE
Change catalog book cover max width

### DIFF
--- a/simplified-ui-catalog/src/main/res/values/dimensions.xml
+++ b/simplified-ui-catalog/src/main/res/values/dimensions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <resources>
-  <dimen name="catalogLaneCoverMaximumWidth">96dp</dimen>
+  <dimen name="catalogLaneCoverMaximumWidth">120dp</dimen>
   <dimen name="catalogBookDetailCoverMaximumWidth">128dp</dimen>
 
   <dimen name="catalogBookDetailStatusHeight">64dp</dimen>


### PR DESCRIPTION
Increased the catalogLaneCoverMaximumWidth
to the same as the maximum height of the cover.

To note: this still limits book covers that
would have more width than height into a square.

Ref SIMPLYE-304