### PR TITLE
Firebase preparation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ plugins {
      */
 
     id("com.google.gms.google-services")
-        .version("4.3.15")
+        .version("4.4.1")
         .apply(false)
 
     /*


### PR DESCRIPTION
Update com.google.gms.google-services version as preparation for later PR in ekirjasto-android-core to enable Firebase.

This version needs to be the same in both ekirjasto-android-core and ekirjasto-android-theme, so the ekirjasto-android-theme PR should be merged first, and then I'll update the submodule commit reference in this PR:
https://github.com/NatLibFi/ekirjasto-android-theme/pull/26