### PR TITLE
Fix intro pages so they show for all devices

### DIFF
--- a/simplified-ui-tutorial/src/main/res/layout/view_tutorial_page.xml
+++ b/simplified-ui-tutorial/src/main/res/layout/view_tutorial_page.xml
@@ -5,5 +5,5 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:contentDescription="@string/contentDescriptionTutorialPage"
-    android:scaleType="centerCrop"
+    android:scaleType="centerInside"
     tools:src="@drawable/background_image_tutorial1" />


### PR DESCRIPTION
Changed the scaling type from centerCrop to centerInside, 
because the text was cut on smaller and bigger screens. Now the
whole image is shown for all screens but there are bars on 
either side of the image in the color of the background for all screen sizes.

Ref SIMPLYE-248