### PR TITLE
Set missing link and delete about app button

### DIFF
--- a/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
+++ b/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
@@ -31,7 +31,10 @@ class EkirjastoDocumentStoreConfiguration : DocumentConfigurationServiceType {
     null
 
   override val eula: DocumentConfiguration? =
-    null
+    DocumentConfiguration(
+      name = null,
+      remoteURI = URI.create("https://www.kansalliskirjasto.fi/fi/e-kirjasto/e-kirjaston-kayttoehdot")
+    )
 
   override val licenses: DocumentConfiguration? =
     null

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -66,7 +66,6 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private lateinit var eulaStatement: TextView
   private lateinit var syncBookmarks: ConstraintLayout
   private lateinit var buttonFeedback: Button
-  private lateinit var buttonAboutApp: Button
   private lateinit var buttonPrivacyPolicy: Button
   private lateinit var buttonUserAgreement: Button
   private lateinit var buttonLicenses: Button
@@ -107,7 +106,6 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.syncBookmarks = view.findViewById(R.id.accountSyncBookmarks)
     this.bookmarkStatement = view.findViewById(R.id.accountSyncBookmarksStatement)
     this.buttonFeedback = view.findViewById(R.id.buttonFeedback)
-    this.buttonAboutApp = view.findViewById(R.id.buttonAboutApp)
     this.buttonPrivacyPolicy = view.findViewById(R.id.buttonPrivacyPolicy)
     this.buttonUserAgreement = view.findViewById(R.id.buttonUserAgreement)
     this.buttonLicenses = view.findViewById(R.id.buttonLicenses)
@@ -215,7 +213,6 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
       is AccountLoginState.AccountLogoutFailed -> OnConfigureAccountLogoutFailed(loginState)
     }
 
-    configureDocViewButton(buttonAboutApp, this.viewModel.documents.about)
     configureDocViewButton(buttonFeedback, this.viewModel.documents.feedback)
     configureDocViewButton(buttonPrivacyPolicy, this.viewModel.documents.privacyPolicy)
     configureDocViewButton(buttonUserAgreement, this.viewModel.documents.eula)

--- a/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
@@ -135,13 +135,6 @@
                 android:paddingBottom="32dp"
                 android:text="@string/account_sync_bookmarks_statement" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/buttonFeedback"
-                style="@style/Palace.Button.Outlined.Settings"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/account_leave_feedback" />
-
         </LinearLayout>
 
         <LinearLayout
@@ -149,7 +142,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
-            android:layout_marginTop="32dp"
+            android:layout_marginTop="40dp"
             android:orientation="vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -158,12 +151,11 @@
             app:layout_constraintTop_toBottomOf="@id/accountTop">
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/buttonAboutApp"
+                android:id="@+id/buttonFeedback"
                 style="@style/Palace.Button.Outlined.Settings"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="0dp"
-                android:text="@string/account_about_app" />
+                android:text="@string/account_leave_feedback" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonPrivacyPolicy"


### PR DESCRIPTION
Set the link for the user agreement webpage in
EkirjastoDocumentStoreConfiguration, and deleted
the aboutApp button from layout file account_ekirjasto.xml, 
and from EkirjastoAccountFragment. Moved the feedback button 
to the spot aboutApp was deleted from, and adjusted the space between 
the top and bottom to count for the missing button.

To note: The license button still should be added when there is something to link to.