### PR TITLE
Fix crash when pressing "Back to service" during Suomi.fi login

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiFragment.kt
@@ -101,6 +101,8 @@ class AccountEkirjastoSuomiFiFragment : Fragment(R.layout.account_ekirjastosuomi
     return when (event) {
       is AccountEkirjastoSuomiFiInternalEvent.WebViewClientReady ->
         this.onWebViewClientReady()
+      is AccountEkirjastoSuomiFiInternalEvent.Cancel ->
+        this.onSuomiFiEventCancel()
       is AccountEkirjastoSuomiFiInternalEvent.Failed ->
         this.onSuomiFiEventFailed(event)
       is AccountEkirjastoSuomiFiInternalEvent.AccessTokenStartReceive ->
@@ -121,6 +123,11 @@ class AccountEkirjastoSuomiFiFragment : Fragment(R.layout.account_ekirjastosuomi
 
   private fun onSuomiFiEventAccessTokenObtained() {
     this.listener.post(AccountEkirjastoSuomiFiEvent.AccessTokenObtained)
+  }
+
+  private fun onSuomiFiEventCancel() {
+    logger.debug("User canceled login, pop from the back stack")
+    this.parentFragmentManager.popBackStack()
   }
 
   private fun onSuomiFiEventFailed(event: AccountEkirjastoSuomiFiInternalEvent.Failed) {

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiInternalEvent.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiInternalEvent.kt
@@ -15,6 +15,13 @@ sealed class AccountEkirjastoSuomiFiInternalEvent {
 
   class WebViewClientReady() : AccountEkirjastoSuomiFiInternalEvent()
 
+
+  /**
+   * User cancelled the process.
+   */
+
+  class Cancel() : AccountEkirjastoSuomiFiInternalEvent()
+
   /**
    * The process failed.
    */


### PR DESCRIPTION
The code assumed that the response from the login was a token, but the response is completely empty if the user cancels the login.

Fixing the crash made canceling the login act like an error, but it's not an error, so I added a "cancel" event to the Suomi.fi login flow, so that canceling is handled a bit more gracefully.

Issue: [SIMPLYE-349](https://jira.lingsoft.fi/browse/SIMPLYE-349)
