### PR TITLE
Make tapping on the header logo to go back to the catalog ("Browse books" tab)

### DIFF
--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
@@ -669,7 +669,7 @@ internal class MainFragmentListenerDelegate(
   }
 
   private fun goUpwards() {
-    logger.error("goUpwards(), stack size: {}", navigator.backStackSize())
+    logger.debug("goUpwards(), stack size: {}", navigator.backStackSize())
     val isRoot = (0 == navigator.backStackSize())
     if (!isRoot) {
       navigator.popBackStack()

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
@@ -669,7 +669,14 @@ internal class MainFragmentListenerDelegate(
   }
 
   private fun goUpwards() {
-    this.navigator.popBackStack()
+    logger.error("goUpwards(), stack size: {}", navigator.backStackSize())
+    val isRoot = (0 == navigator.backStackSize())
+    if (!isRoot) {
+      navigator.popBackStack()
+    }
+    else {
+      openCatalog()
+    }
   }
 
   private fun openSettingsAccount(

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedFragment.kt
@@ -602,11 +602,11 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
        * If the change accounts UI is disabled, check if logo should be shown.
        */
       if (this.configurationService.showActionBarLogo) {
-        // Show the logo, but don't make it act like a button
+        // Show the logo, make it go back to the catalog ("Browse books" tab)
         actionBar.setLogo(this.configurationService.brandingAppIcon)
         actionBar.setDisplayHomeAsUpEnabled(false)
         this.toolbar.setLogoOnClickListener {
-          // Do nothing
+          this.viewModel.goUpwards()
         }
         return
       }


### PR DESCRIPTION
Make tapping on the header logo to go back to the catalog ("Browse books" tab).

Issue: [SIMPLYE-347](https://jira.lingsoft.fi/browse/SIMPLYE-347)
