### PR TITLE
Show Alert dialog when ekirjasto account could not be obtained

### DIFF
--- a/simplified-ui-tutorial/src/main/java/org/librarysimplified/ui/login/LoginMainFragment.kt
+++ b/simplified-ui-tutorial/src/main/java/org/librarysimplified/ui/login/LoginMainFragment.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.librarysimplified.services.api.Services
 import org.librarysimplified.ui.tutorial.R
 import org.nypl.simplified.accounts.api.AccountID
@@ -223,22 +224,36 @@ class LoginMainFragment : Fragment(R.layout.login_main_fragment) {
 
   private fun openEkirjastoLogin(method: EkirjastoLoginMethod) {
 
-    val account = pickDefaultAccount(profilesController, accountProviders.defaultProvider)
-    val authentication = account.provider.authentication as AccountProviderAuthenticationDescription.Ekirjasto
+    try {
+      val account = pickDefaultAccount(profilesController, accountProviders.defaultProvider)
+      val authentication =
+        account.provider.authentication as AccountProviderAuthenticationDescription.Ekirjasto
+      when (method) {
+        is EkirjastoLoginMethod.SuomiFi -> openSuomiFiLogin(
+          profilesController,
+          account.id,
+          authentication
+        )
 
-    when (method) {
-      is EkirjastoLoginMethod.SuomiFi -> openSuomiFiLogin(
-        profilesController,
-        account.id,
-        authentication
-      )
-
-      is EkirjastoLoginMethod.Passkey -> openPasskeyLogin(
-        profilesController,
-        account.id,
-        authentication
-      )
+        is EkirjastoLoginMethod.Passkey -> openPasskeyLogin(
+          profilesController,
+          account.id,
+          authentication
+        )
+      }
+    } catch (e: ClassCastException) {
+      this.logger.error("Failed to obtain EKirjasto authentication description",e)
+      showErrorAlert(requireContext().getString(R.string.error_login_account_not_found))
+    } catch (e: Exception) {
+      this.logger.error("Ekirjasto Login Unknown error",e)
     }
+
+  }
+
+  private fun showErrorAlert(message: String) {
+    MaterialAlertDialogBuilder(requireContext())
+      .setMessage(message)
+      .show()
   }
 
   private fun openSuomiFiLogin(

--- a/simplified-ui-tutorial/src/main/res/values/strings.xml
+++ b/simplified-ui-tutorial/src/main/res/values/strings.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-  <!-- Accessibility -->
-  <string name="contentDescriptionTutorialPage">Tutorial page</string>
-  <string name="contentDescriptionSkipButton">Skip button</string>
-  <string name="contentDescriptionStep1">Step 1 - Find your library</string>
-  <string name="contentDescriptionStep2">Step 2 - Can\'t find your library? Go to the E-kirjasto Bookshelf for more than 10000 free titles that you can enjoy now</string>
-  <string name="contentDescriptionStep3">Step 3 - Read. Listen. Enjoy!</string>
+    <!-- Accessibility -->
+    <string name="contentDescriptionTutorialPage">Tutorial page</string>
+    <string name="contentDescriptionSkipButton">Skip button</string>
+    <string name="contentDescriptionStep1">Step 1 - Find your library</string>
+    <string name="contentDescriptionStep2">Step 2 - Can\'t find your library? Go to the E-kirjasto Bookshelf for more than 10000 free titles that you can enjoy now</string>
+    <string name="contentDescriptionStep3">Step 3 - Read. Listen. Enjoy!</string>
     <string name="login_suomifi">Sign in with Suomi.fi</string>
-  <string name="login_passkey">Sign in with a passkey</string>
-  <string name="skip_login">Continue without signing in</string>
+    <string name="login_passkey">Sign in with a passkey</string>
+    <string name="skip_login">Continue without signing in</string>
+    <string name="error_login_account_not_found">Error logging in. Please restart app and try again.</string>
 
 </resources>


### PR DESCRIPTION
**What's this do?**
[Description of what this PR does goes here]
Avoid app crashing by showing error dialog if ekirjasto account could not be obtained during login.

Workaround (not a fix) to: https://jira.lingsoft.fi/browse/SIMPLYE-351

**Why are we doing this? (w/ JIRA link if applicable)**
[Quick blurb about why the code is needed and Jira link goes here / Do these changes meet the business requirements of the story?]

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Have you updated the changelog?**

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
