### PR TITLE
Simplye 369-370372-373 increase touch target sizes

### DIFF
--- a/simplified-ui-catalog/src/main/res/layout/book_detail.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail.xml
@@ -155,8 +155,9 @@
             android:id="@+id/seeMoreText"
             style="@style/MoreTextStyle"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="48dp"
             android:layout_gravity="end"
+            android:gravity="center_vertical"
             android:layout_marginEnd="16dp"
             android:text="@string/catalogDetailsMore" />
 

--- a/simplified-ui-catalog/src/main/res/layout/feed_header.xml
+++ b/simplified-ui-catalog/src/main/res/layout/feed_header.xml
@@ -9,7 +9,7 @@
   <RadioGroup
     android:id="@+id/feedHeaderTabs"
     android:layout_width="match_parent"
-    android:layout_height="40dp"
+    android:layout_height="48dp"
     android:layout_margin="16dp"
     android:gravity="center_horizontal"
     android:orientation="horizontal"

--- a/simplified-ui-catalog/src/main/res/layout/feed_lane.xml
+++ b/simplified-ui-catalog/src/main/res/layout/feed_lane.xml
@@ -10,9 +10,9 @@
   <LinearLayout
       android:id="@+id/feedLaneTitleContainer"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
+      android:layout_height="48dp"
       android:layout_marginLeft="16dp"
-      android:layout_marginTop="16dp"
+      android:layout_marginTop="8dp"
       android:layout_marginEnd="16dp"
       android:layout_marginBottom="8dp"
       android:gravity="center_vertical"
@@ -25,6 +25,7 @@
         android:layout_marginEnd="16dp"
         android:layout_weight="1"
         android:ellipsize="end"
+        android:gravity="center_vertical"
         android:maxLines="1"
         android:text="@string/catalogPlaceholder"
         android:textSize="18sp"
@@ -37,6 +38,7 @@
         android:layout_marginEnd="0dp"
         android:layout_weight="0"
         android:text="@string/catalogMore"
+        android:gravity="center_vertical"
         android:textSize="14sp" />
 
   </LinearLayout>

--- a/simplified-ui-tutorial/src/main/res/layout/fragment_tutorial.xml
+++ b/simplified-ui-tutorial/src/main/res/layout/fragment_tutorial.xml
@@ -21,11 +21,12 @@
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tutorial_tab_layout"
         android:layout_width="wrap_content"
-        android:layout_height="16dp"
+        android:layout_height="48dp"
         android:layout_gravity="bottom|center_horizontal"
         android:layout_marginBottom="24dp"
         app:tabBackground="@drawable/selector_tab"
-        app:tabIndicatorHeight="0dp"
-        app:tabMaxWidth="16dp" />
+        app:tabMinWidth="48dp"
+        app:tabPadding="16dp"
+        app:tabIndicatorHeight="0dp" />
 
 </FrameLayout>

--- a/simplified-ui-tutorial/src/main/res/layout/fragment_tutorial.xml
+++ b/simplified-ui-tutorial/src/main/res/layout/fragment_tutorial.xml
@@ -26,7 +26,6 @@
         android:layout_marginBottom="24dp"
         app:tabBackground="@drawable/selector_tab"
         app:tabMinWidth="48dp"
-        app:tabPadding="16dp"
         app:tabIndicatorHeight="0dp" />
 
 </FrameLayout>


### PR DESCRIPTION
Increased the touch target sizes for different 
areas in the app. These are the ones that are not 
in the search bar/toolbar area.

To note: The change to button sizes on tutorial page
made it so that the circle size increased and it is now
pixelated. Also the Ripple effect looks a little weird.

Ref SIMPLYE-369 SIMPLYE-370 SIMPLYE-372 SIMPLYE-373

