### PR TITLE
Fix Suomi.fi login when the app returns to the foreground

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiFragment.kt
@@ -1,5 +1,6 @@
 package org.nypl.simplified.ui.accounts.ekirjasto.suomifi
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import android.view.View.INVISIBLE
@@ -65,11 +66,17 @@ class AccountEkirjastoSuomiFiFragment : Fragment(R.layout.account_ekirjastosuomi
   private lateinit var progress: ProgressBar
   private lateinit var webView: WebView
 
+  @SuppressLint("SetJavaScriptEnabled")
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    logger.debug("onViewCreated(), recreating: {}", (savedInstanceState != null))
     super.onViewCreated(view, savedInstanceState)
     this.progress = view.findViewById(R.id.suomifiprogressBar)
     this.webView = view.findViewById(R.id.suomifiWebView)
     WebViewUtilities.setForcedDark(this.webView.settings, resources.configuration)
+
+    if (this.viewModel.isWebViewClientReady) {
+      this.loadLoginPage()
+    }
   }
 
   override fun onStart() {
@@ -86,13 +93,10 @@ class AccountEkirjastoSuomiFiFragment : Fragment(R.layout.account_ekirjastosuomi
     this.webView.webChromeClient = AccountEkirjastoSuomiFiChromeClient(this.progress)
     this.webView.webViewClient = this.viewModel.webViewClient
     this.webView.settings.javaScriptEnabled = true
-
-    if (this.viewModel.isWebViewClientReady) {
-      this.loadLoginPage()
-    }
   }
 
   private fun loadLoginPage() {
+    logger.debug("loadLoginPage()")
     val urlSuffix = "&state=app"
     this.webView.loadUrl("${this.parameters.authenticationDescription.tunnistus_start}${urlSuffix}")
   }

--- a/simplified-ui-tutorial/src/main/java/org/librarysimplified/ui/login/LoginMainFragment.kt
+++ b/simplified-ui-tutorial/src/main/java/org/librarysimplified/ui/login/LoginMainFragment.kt
@@ -57,10 +57,14 @@ class LoginMainFragment : Fragment(R.layout.login_main_fragment) {
     get() = this.defaultViewModelFactory
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    logger.debug("onViewCreated(), recreating: {}", (savedInstanceState != null))
     super.onViewCreated(view, savedInstanceState)
 
     mainContainer = view.findViewById(R.id.login_main_container)
 
+    if (!checkIsLoggedIn()) {
+      openLoginUi()
+    }
   }
 
   override fun onAttach(context: Context) {
@@ -84,11 +88,10 @@ class LoginMainFragment : Fragment(R.layout.login_main_fragment) {
   }
   override fun onStart() {
     super.onStart()
+
     this.listenerRepository.registerHandler(this::handleEvent)
-    if (checkIsLoggedIn()){
+    if (checkIsLoggedIn()) {
       this.listener.post(MainLoginEvent.LoginSuccess)
-    } else {
-      openLoginUi()
     }
   }
 


### PR DESCRIPTION
The Suomi.fi login got "reset" back to the front page when the app returned from the background to the foreground, which is a common use case for logging in with bank credentials (you switch to the banking app and back). Fixed by moving the openLoginUi()/openLoginPage() calls from the fragments' onStart() to onViewCreated().
