### PR TITLE
Add themes changes and set minHeight for the toolbar

### DIFF
--- a/simplified-main/src/main/res/layout/main_host.xml
+++ b/simplified-main/src/main/res/layout/main_host.xml
@@ -8,6 +8,7 @@
   <org.thepalaceproject.theme.core.PalaceToolbar
     android:id="@+id/mainToolbar"
     android:layout_width="match_parent"
+    android:minHeight="@dimen/PalaceToolbarHeight"
     android:layout_height="@dimen/PalaceToolbarHeight" />
 
   <FrameLayout


### PR DESCRIPTION
Pulled the theme changes from ekirjasto-theme.
Added a minHeight to the PalaceToolbar which is
the height of the toolbar. The minHeight
measure is used to vertically allign things in
the toolbar. Adding this affected the search button 
and search bar sizes, increasing their height to
48dp and centering them vertically.

Ref SIMPLYE-371 SIMPLYE-374 SIMPLYE-375