### PR TITLE
Allow cleartext network traffic for localhost (127.0.0.1)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,6 +34,8 @@ org.thepalaceproject.build.jdkBytecodeTarget=11
 org.thepalaceproject.build.jdkBuild=17
 org.thepalaceproject.build.publishSources=false
 
+ekirjasto.versionName=1.0.1
+
 # If true, enable StrictMode checking in debug builds
 # Useful when trying to find performance issues, but also makes for noisy logs
 ekirjasto.enableStrictMode=false

--- a/simplified-app-ekirjasto/build.gradle.kts
+++ b/simplified-app-ekirjasto/build.gradle.kts
@@ -30,6 +30,12 @@ fun overrideProperty(name: String) : String {
     return value
 }
 
+
+fun getVersionName(): String {
+    return overrideProperty("ekirjasto.versionName")
+}
+
+
 apply(plugin = "com.google.gms.google-services")
 apply(plugin = "com.google.firebase.crashlytics")
 
@@ -139,7 +145,7 @@ android {
     }
     defaultConfig {
         applicationId = "fi.kansalliskirjasto.ekirjasto"
-        versionName = "1.0.0"
+        versionName = getVersionName()
         versionCode = calculateVersionCode()
         val languages = overrideProperty("ekirjasto.languages")
         println("Configured languages: $languages")

--- a/simplified-app-ekirjasto/src/main/res/xml/network_security_config.xml
+++ b/simplified-app-ekirjasto/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
   <base-config cleartextTrafficPermitted="false" />
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">127.0.0.1</domain>
+  </domain-config>
   <debug-overrides>
     <trust-anchors>
       <certificates src="user"/>


### PR DESCRIPTION
Opening books broke because a recent commit disabled allowing cleartext network traffic (HTTP instead of HTTPS). The change was made because of a security warning in Google Play Console. However, this broke loading book resources from localhost (127.0.0.1).

This commit changes the config to allow cleartext network traffic again, but this time only for localhost. This fixes opening books, hopefully the security warning won't come back. Even if it does, this isn't really a security issue. If the warning comes back it might be possible to use `file://` instead of `http://127.0.0.1/`.
