### PR TITLE
Allow HTTP globally

### DIFF
--- a/simplified-app-ekirjasto/src/main/res/xml/network_security_config.xml
+++ b/simplified-app-ekirjasto/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-  <base-config cleartextTrafficPermitted="false" />
-  <domain-config cleartextTrafficPermitted="true">
-    <domain includeSubdomains="true">127.0.0.1</domain>
-  </domain-config>
+  <base-config cleartextTrafficPermitted="true" />
   <debug-overrides>
     <trust-anchors>
       <certificates src="user"/>


### PR DESCRIPTION
Unfortunately, enabling HTTP for only localhost/127.0.0.1 is not enough, even though that's the only place where it appears to be used...
