### PR TITLE
Change tutorial page descriptions to match images

### DIFF
--- a/simplified-ui-tutorial/src/main/java/org/librarysimplified/ui/tutorial/TutorialFragment.kt
+++ b/simplified-ui-tutorial/src/main/java/org/librarysimplified/ui/tutorial/TutorialFragment.kt
@@ -81,13 +81,16 @@ class TutorialFragment : Fragment(R.layout.fragment_tutorial) {
       tab.contentDescription = getString(
         when (position) {
           0 -> {
-            R.string.contentDescriptionStep1
+            R.string.contentDescriptionPage1
           }
           1 -> {
-            R.string.contentDescriptionStep2
+            R.string.contentDescriptionPage2
+          }
+          2 -> {
+            R.string.contentDescriptionPage3
           }
           else -> {
-            R.string.contentDescriptionStep3
+            R.string.contentDescriptionPage4
           }
         }
       )

--- a/simplified-ui-tutorial/src/main/res/values/strings.xml
+++ b/simplified-ui-tutorial/src/main/res/values/strings.xml
@@ -4,9 +4,10 @@
     <!-- Accessibility -->
     <string name="contentDescriptionTutorialPage">Tutorial page</string>
     <string name="contentDescriptionSkipButton">Skip button</string>
-    <string name="contentDescriptionStep1">Step 1 - Find your library</string>
-    <string name="contentDescriptionStep2">Step 2 - Can\'t find your library? Go to the E-kirjasto Bookshelf for more than 10000 free titles that you can enjoy now</string>
-    <string name="contentDescriptionStep3">Step 3 - Read. Listen. Enjoy!</string>
+    <string name="contentDescriptionPage1">Welcome to the E-library! This service is provided by your local library.</string>
+    <string name="contentDescriptionPage2">You can browse e-books and audiobooks by genre, book or author, or browse recommendation lists made by librarians.</string>
+    <string name="contentDescriptionPage3">Browse the selection, borrow and read or listen! If a book is on loan, press "reserve" to get it when it becomes available.</string>
+    <string name="contentDescriptionPage4">Or do you want something to listen to? The collection also includes an untold number of audiobooks! Click "borrow" to listen to the audiobook.</string>
     <string name="login_suomifi">Sign in with Suomi.fi</string>
     <string name="login_passkey">Sign in with a passkey</string>
     <string name="skip_login">Continue without signing in</string>


### PR DESCRIPTION
Changed the contentDescription strings for the
tutorial pages to match the text present in the actual
images. This way correct text is read outloud by a screen reader.

Ref EKIR-111