### PR TITLE
Change the color of icon in primary buttons

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogTimedLoanDrawable.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogTimedLoanDrawable.kt
@@ -28,7 +28,7 @@ class CatalogTimedLoanDrawable(
   }
 
   override fun draw(canvas: Canvas) {
-    val color = this.context.getColor(org.thepalaceproject.theme.core.R.color.PalaceTextColor)
+    val color = this.context.getColor(org.thepalaceproject.theme.core.R.color.EkirjastoBlack)
     this.paint.color = color
     this.paint.textSize = 16.0f
 


### PR DESCRIPTION
Changed the color to EkirjastoBlack so the
small text and icon stays black and visible
when in dark mode.

Ref SIMPLYE-365