### PR TITLE
Add Google Review instructions

### DIFF
--- a/docs/Google-Play-review-instructions.md
+++ b/docs/Google-Play-review-instructions.md
@@ -1,0 +1,24 @@
+# Review instructions for Google Play
+
+Normally, the app only supports strong identification through Suomi.fi, meaning
+that users normally log in using their bank credentials (or some other form of
+strong identification).
+
+For review purposes, the app has a "test login" page, which can be accessed
+only through a deep link.
+
+Please follow these instructions to review the app:
+1. make sure the app is closed (not running in the background)
+2. then click this link on the test device:
+   - [ekirjasto://test-login]
+3. this opens a test login page (accessible only with the above deep link)
+4. input the test login credentials given in Google Play Console
+5. after pressing "Login" on the test login page, the app will reload and show
+   the app's normal login page
+6. on the normal login page, choose "Sign in with Suomi.fi"
+7. on the next page ("e-Identification"), scroll down and choose "Test IdP"
+8. on the next page ("Tunnistus"), above the "Henkilötunnus" input box, click
+   the link labeled "Käytä oletusta 210281-9988" and then click "Tunnistaudu"
+9. on the next page, click "Continue to service"
+
+After the above steps, you are logged in like regular users.


### PR DESCRIPTION
Google Play Console has a 500 character limit for review instructions, which is a bit too short to properly describe the test login process, so let's add instructions into the repository, which can then be linked to from Google Play Console's instructions.
