### PR TITLE
Clear app data and restart the app when the build flavor has changed

### DIFF
--- a/simplified-ekirjasto-testing-ui/build.gradle.kts
+++ b/simplified-ekirjasto-testing-ui/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation(project(":simplified-books-registry-api"))
     implementation(project(":simplified-buildconfig-api"))
     implementation(project(":simplified-ekirjasto-testing"))
+    implementation(project(":simplified-ekirjasto-util"))
     implementation(project(":simplified-feeds-api"))
     implementation(project(":simplified-futures"))
     implementation(project(":simplified-mdc"))

--- a/simplified-ekirjasto-testing-ui/src/main/java/fi/kansalliskirjasto/ekirjasto/testing/ui/TestLoginFragment.kt
+++ b/simplified-ekirjasto-testing-ui/src/main/java/fi/kansalliskirjasto/ekirjasto/testing/ui/TestLoginFragment.kt
@@ -1,9 +1,7 @@
 package fi.kansalliskirjasto.ekirjasto.testing.ui
 
 import android.annotation.SuppressLint
-import android.app.ActivityManager
 import android.content.Context
-import android.content.Context.ACTIVITY_SERVICE
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
 import android.os.Bundle
@@ -16,13 +14,12 @@ import android.widget.EditText
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.fragment.app.Fragment
-import com.jakewharton.processphoenix.ProcessPhoenix
 import fi.ekirjasto.testing.ui.BuildConfig
 import fi.ekirjasto.testing.ui.R
+import fi.kansalliskirjasto.ekirjasto.util.DataUtil
 import fi.kansalliskirjasto.ekirjasto.testing.TestingOverrides
 import org.nypl.simplified.android.ktx.supportActionBar
 import org.slf4j.LoggerFactory
-import java.io.File
 
 
 /**
@@ -72,7 +69,7 @@ class TestLoginFragment(
 
     if (!testLoginEnabled) {
       logger.error("Test login is disabled")
-      restartApp()
+      DataUtil.restartApp(requireContext())
       return
     }
 
@@ -125,7 +122,7 @@ class TestLoginFragment(
     }
 
     loginButton.setOnClickListener { checkLogin() }
-    clearAppDataButton.setOnClickListener { clearAppDataAndExit() }
+    clearAppDataButton.setOnClickListener { DataUtil.clearAppDataAndExit(requireContext()) }
   }
 
   private fun checkLogin() {
@@ -133,7 +130,7 @@ class TestLoginFragment(
 
     if (!testLoginEnabled) {
       logger.error("Test login is disabled")
-      restartApp()
+      DataUtil.restartApp(requireContext())
       return
     }
 
@@ -159,18 +156,8 @@ class TestLoginFragment(
     loadingLayout.visibility = View.VISIBLE
     loginLayout.visibility = View.GONE
     setTestLoginActive()
-    deleteEverythingExceptSharedPrefs()
-    restartApp()
-  }
-
-  private fun clearAppDataAndExit() {
-    logger.warn("clearAppDataAndExit()")
-    (context?.getSystemService(ACTIVITY_SERVICE) as ActivityManager).clearApplicationUserData()
-  }
-  
-  private fun restartApp() {
-    logger.warn("restartApp()")
-    ProcessPhoenix.triggerRebirth(requireContext())
+    DataUtil.deleteEverythingExceptSharedPrefs(requireContext())
+    DataUtil.restartApp(requireContext())
   }
 
   private fun hideVirtualKeyboard() {
@@ -187,31 +174,5 @@ class TestLoginFragment(
     prefsEditor.putBoolean("testLoginActive", true)
     prefsEditor.commit()
     TestingOverrides.testLoginActive = true
-  }
-  
-  private fun deleteRecursively(fileOrDirectory: File, ignore: String? = null) {
-    if (ignore != null && fileOrDirectory.path.contains(ignore)) {
-      return
-    }
-
-    logger.debug("deleteRecursivelyInner({})", fileOrDirectory)
-
-    if (fileOrDirectory.isDirectory()) {
-      for (child in fileOrDirectory.listFiles() ?: arrayOf()) {
-        deleteRecursively(child, ignore)
-      }
-    }
-
-    fileOrDirectory.delete()
-  }
-
-  private fun deleteEverythingExceptSharedPrefs() {
-    logger.warn("deleteEverythingExceptSharedPrefs()")
-    val basePath = requireActivity().filesDir.parent!! + File.separator
-    deleteRecursively(File(basePath), "shared_prefs")
-    //deleteRecursively(File("${basePath}cache"))
-    //deleteRecursively(File("${basePath}databases"))
-    //deleteRecursively(File("${basePath}files"))
-    //deleteRecursively(File("${basePath}no_backup"))
   }
 }

--- a/simplified-ekirjasto-testing/src/main/java/fi/kansalliskirjasto/ekirjasto/testing/TestingOverrides.kt
+++ b/simplified-ekirjasto-testing/src/main/java/fi/kansalliskirjasto/ekirjasto/testing/TestingOverrides.kt
@@ -1,5 +1,7 @@
 package fi.kansalliskirjasto.ekirjasto.testing
 
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
 import fi.ekirjasto.testing.BuildConfig
 
 /**
@@ -7,8 +9,23 @@ import fi.ekirjasto.testing.BuildConfig
  */
 sealed class TestingOverrides {
   companion object {
+    private var initialized = false
+
+    private const val SHARED_PREFS_NAME = "EkirjastoTesting"
+
     var testLoginActive: Boolean = false
     const val TEST_LOGIN_CIRCULATION_API_URL: String = BuildConfig.TEST_LOGIN_CIRCULATION_API_URL
     const val TEST_LOGIN_LIBRARY_PROVIDER_ID: String = BuildConfig.TEST_LOGIN_LIBRARY_PROVIDER_ID
+
+    fun init(context: Context) {
+      if (initialized) {
+        return
+      }
+
+      val testingPrefs = context.getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE)
+      testLoginActive = testingPrefs.getBoolean("testLoginActive", false)
+
+      initialized = true
+    }
   }
 }

--- a/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/AppInfoUtil.kt
+++ b/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/AppInfoUtil.kt
@@ -1,0 +1,59 @@
+package fi.kansalliskirjasto.ekirjasto.util
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
+import fi.ekirjasto.util.BuildConfig
+import org.slf4j.LoggerFactory
+
+/**
+ * App info related utilities.
+ */
+sealed class AppInfoUtil {
+  companion object {
+    private val logger = LoggerFactory.getLogger(AppInfoUtil::class.java)
+
+    private var initialized = false
+
+    private const val SHARED_PREFS_NAME = "EkirjastoAppInfo"
+
+    var hasBuildFlavorChanged = false
+      private set
+
+    val buildFlavor: String
+      get() {
+        return BuildConfig.FLAVOR
+      }
+
+    fun init(context: Context) {
+      if (initialized) {
+        return
+      }
+
+      val previousBuildFlavor = getSavedBuildFlavor(context)
+      hasBuildFlavorChanged =
+        (previousBuildFlavor != null)
+          && (buildFlavor != previousBuildFlavor)
+      logger.info("Current build flavor:  $buildFlavor")
+      logger.info("Previous build flavor: $previousBuildFlavor")
+      logger.info("Build flavor changed:  $hasBuildFlavorChanged")
+
+      saveBuildFlavor(context)
+
+      initialized = true
+    }
+
+    private fun getSavedBuildFlavor(context: Context): String? {
+      val prefs = context.getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE)
+      return prefs.getString("buildFlavor", null)
+    }
+    
+    @SuppressLint("ApplySharedPref")
+    private fun saveBuildFlavor(context: Context) {
+      val prefs = context.getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE)
+      val prefsEditor = prefs.edit()
+      prefsEditor.putString("buildFlavor", buildFlavor)
+      prefsEditor.commit()
+    }
+  }
+}

--- a/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/DataUtil.kt
+++ b/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/DataUtil.kt
@@ -1,0 +1,53 @@
+package fi.kansalliskirjasto.ekirjasto.util
+
+import android.app.ActivityManager
+import android.content.Context
+import android.content.Context.ACTIVITY_SERVICE
+import com.jakewharton.processphoenix.ProcessPhoenix
+import org.slf4j.LoggerFactory
+import java.io.File
+
+/**
+ * App data related utilities.
+ */
+sealed class DataUtil {
+  companion object {
+    private val logger = LoggerFactory.getLogger(DataUtil::class.java)
+
+    fun clearAppDataAndExit(context: Context) {
+      logger.warn("clearAppDataAndExit()")
+      (context.getSystemService(ACTIVITY_SERVICE) as ActivityManager).clearApplicationUserData()
+    }
+
+    fun deleteEverythingExceptSharedPrefs(context: Context) {
+      logger.warn("deleteEverythingExceptSharedPrefs()")
+      val basePath = context.filesDir.parent!! + File.separator
+      deleteRecursively(File(basePath), "shared_prefs")
+      //deleteRecursively(File("${basePath}cache"))
+      //deleteRecursively(File("${basePath}databases"))
+      //deleteRecursively(File("${basePath}files"))
+      //deleteRecursively(File("${basePath}no_backup"))
+    }
+
+    fun restartApp(context: Context, delay: Long = 0L) {
+      logger.warn("restartApp()")
+      ProcessPhoenix.triggerRebirth(context)
+    }
+
+    private fun deleteRecursively(fileOrDirectory: File, ignore: String? = null) {
+      if (ignore != null && fileOrDirectory.path.contains(ignore)) {
+        return
+      }
+
+      logger.debug("deleteRecursivelyInner({})", fileOrDirectory)
+
+      if (fileOrDirectory.isDirectory()) {
+        for (child in fileOrDirectory.listFiles() ?: arrayOf()) {
+          deleteRecursively(child, ignore)
+        }
+      }
+
+      fileOrDirectory.delete()
+    }
+  }
+}

--- a/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/LanguageUtil.kt
+++ b/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/LanguageUtil.kt
@@ -6,12 +6,12 @@ import java.net.URI
 import java.net.URL
 
 /**
- * Override values for testing the app.
+ * Language and localization related utilities.
  */
 sealed class LanguageUtil {
   companion object {
     /**
-     * Get the language that digital magazines should use.
+     * Get the user's language.
      */
     fun getUserLanguage(): String {
       // Get the list of languages supported by the app


### PR DESCRIPTION
The app currently cannot properly handle a situation where the circulation backend has changed since the last time the app has run. The app will keep using the previous (cached) circulation URL until app data is cleared. This is beyond many users' know-how, so let's automatically wipe app data if the app flavor has changed. This should only happen if we have accidentally published the wrong app flavor (but commonly happens during development).

If there is no flavor saved to persistent storage (SharedPrefs), the app will **not** wipe data. This is necessary for 2 reasons:
- new installs would immediately wipe data unnecessarily
- previous installs that don't save the flavor name to storage (i.e. previous installs before this commit) would wipe data, whether it's necessary or not