### PR TITLE
Fix lanes showing only the first page (50 titles)

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
@@ -621,7 +621,7 @@ class CatalogFeedViewModel(
     val pagedListConfig =
       PagedList.Config.Builder()
         .setEnablePlaceholders(true)
-        .setPageSize(50)
+        .setPageSize(100)
         .setMaxSize(250)
         .setPrefetchDistance(25)
         .build()

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogPagedDataSource.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogPagedDataSource.kt
@@ -40,8 +40,6 @@ class CatalogPagedDataSource(
 
     callback.onResult(
       this.initialFeed.entriesInOrder,
-      0,
-      this.initialFeed.entriesInOrder.size,
       null,
       this.initialFeed.feedNext
     )


### PR DESCRIPTION
When browsing a lane, the app was only fetching the first page of results (the first 50 titles), and didn't fetch the next page(s) at all. This was a bug in the upstream app, copied those changes over.

Tested with the "All Fiction" lane in circulation-beta and with the "All Nonfiction" lane in lib-dev, which both have over 50 titles (more than 1 page of results).

There are currently no lanes with 100+ titles in any of the development circulation backends, so I wasn't able to test that, but will confirm that later. I'm not expecting anything to break in that case, but would be nice to confirm.

Issue: [SIMPLYE-393](https://jira.lingsoft.fi/browse/SIMPLYE-393)
