### PR TITLE
Bump version to 1.0.5-dev (1.0.4 has been released)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ org.thepalaceproject.build.jdkBytecodeTarget=11
 org.thepalaceproject.build.jdkBuild=17
 org.thepalaceproject.build.publishSources=false
 
-ekirjasto.versionName=1.0.4
+ekirjasto.versionName=1.0.5-dev
 
 # If true, enable StrictMode checking in debug builds
 # Useful when trying to find performance issues, but also makes for noisy logs


### PR DESCRIPTION
Bump version to 1.0.5-dev (1.0.4 has been released)