### PR TITLE
Passkeys only enabled on API level 28+

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -26,6 +26,8 @@ import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggingInWaitin
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoginFailed
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountNotLoggedIn
 import org.nypl.simplified.android.ktx.supportActionBar
+import org.nypl.simplified.bookmarks.api.BookmarkSyncEnableResult
+import org.nypl.simplified.bookmarks.api.BookmarkSyncEnableStatus
 import org.nypl.simplified.listeners.api.FragmentListenerType
 import org.nypl.simplified.listeners.api.fragmentListeners
 import org.nypl.simplified.profiles.controller.api.ProfileAccountLoginRequest
@@ -34,8 +36,6 @@ import org.nypl.simplified.ui.accounts.AccountFragmentParameters
 import org.nypl.simplified.ui.accounts.ekirjasto.suomifi.EkirjastoLoginMethod
 import org.slf4j.LoggerFactory
 import org.thepalaceproject.theme.core.PalaceToolbar
-import java.net.URI
-import java.net.URL
 
 class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private val logger =
@@ -115,6 +115,7 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.buttonLicenses = view.findViewById(R.id.buttonLicenses)
     this.buttonFaq = view.findViewById(R.id.buttonFaq)
     this.versionText = view.findViewById(R.id.appVersion)
+    this.bookmarkSyncCheck = view.findViewById(R.id.accountSyncBookmarksCheck)
 
 
     this.toolbar =
@@ -124,6 +125,10 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
 
     this.viewModel.accountLive.observe(this.viewLifecycleOwner) {
       this.reconfigureAccountUI()
+    }
+
+    this.viewModel.accountSyncingSwitchStatus.observe(this.viewLifecycleOwner){ status ->
+      this.reconfigureBookmarkSyncingSwitch(status)
     }
 
     this.reconfigureAccountUI()
@@ -153,10 +158,10 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     /*
      * Configure the bookmark syncing switch to enable/disable syncing permissions.
      */
-// TODO bookmark sync
-//    this.bookmarkSyncCheck.setOnCheckedChangeListener { _, isChecked ->
-//      this.viewModel.enableBookmarkSyncing(isChecked)
-//    }
+
+    this.bookmarkSyncCheck.setOnCheckedChangeListener { _, isChecked ->
+      this.viewModel.enableBookmarkSyncing(isChecked)
+    }
 
     /*
      * Hide the toolbar and back arrow if there is no page to return to (e.g. coming from a deep link).
@@ -206,6 +211,10 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
 
   private fun reconfigureAccountUI() {
 
+    if (!isPasskeySupported()) {
+      this.buttonRegisterPasskey.visibility = GONE
+      this.buttonLoginPasskey.visibility = GONE
+    }
     val loginState = this.viewModel.account.loginState
     this.logger.debug("Configure UI Account Login State: {}",loginState)
     when (loginState){
@@ -234,10 +243,11 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.buttonLoginSuomiFi.isEnabled = true
     buttonLogout.visibility = GONE
     buttonLoginSuomiFi.visibility = VISIBLE
-    //TODO enable once passkeys fixed
-    buttonLoginPasskey.visibility = VISIBLE
-//    buttonLoginPasskey.visibility = GONE
-    buttonRegisterPasskey.visibility = GONE
+
+    if (isPasskeySupported()) {
+      buttonLoginPasskey.visibility = VISIBLE
+      buttonRegisterPasskey.visibility = GONE
+    }
     this.syncBookmarks.visibility = GONE
     this.bookmarkStatement.visibility = GONE
     this.eulaStatement.visibility = VISIBLE
@@ -248,10 +258,11 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.buttonLoginPasskey.isEnabled = false
     buttonLogout.visibility = GONE
     buttonLoginSuomiFi.visibility = VISIBLE
-    //TODO enable once passkeys fixed
-    buttonLoginPasskey.visibility = VISIBLE
-//    buttonLoginPasskey.visibility = GONE
-    buttonRegisterPasskey.visibility = GONE
+
+    if (isPasskeySupported()) {
+      buttonLoginPasskey.visibility = VISIBLE
+      buttonRegisterPasskey.visibility = GONE
+    }
   }
 
   private fun OnConfigureWaitingForExternalAuth(loginState: AccountLoggingInWaitingForExternalAuthentication) {
@@ -259,10 +270,11 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.buttonLoginPasskey.isEnabled = false
     buttonLogout.visibility = GONE
     buttonLoginSuomiFi.visibility = VISIBLE
-    //TODO enable once passkeys fixed
-    buttonLoginPasskey.visibility = VISIBLE
-//    buttonLoginPasskey.visibility = GONE
-    buttonRegisterPasskey.visibility = GONE
+
+    if (isPasskeySupported()) {
+      buttonLoginPasskey.visibility = VISIBLE
+      buttonRegisterPasskey.visibility = GONE
+    }
   }
 
   private fun OnConfigureAccountLoginFailed(loginState: AccountLoginFailed) {
@@ -270,10 +282,11 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.buttonLoginPasskey.isEnabled = true
     buttonLogout.visibility = GONE
     buttonLoginSuomiFi.visibility = VISIBLE
-    //TODO enable once passkeys fixed
-    buttonLoginPasskey.visibility = VISIBLE
-//    buttonLoginPasskey.visibility = GONE
-    buttonRegisterPasskey.visibility = GONE
+
+    if (isPasskeySupported()) {
+      buttonLoginPasskey.visibility = VISIBLE
+      buttonRegisterPasskey.visibility = GONE
+    }
     this.syncBookmarks.visibility = GONE
 
   }
@@ -281,10 +294,10 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private fun OnConfigureAccountLoggedIn(loginState: AccountLoggedIn) {
     buttonLogout.visibility = VISIBLE
     buttonLoginSuomiFi.visibility = GONE
-    buttonLoginPasskey.visibility = GONE
-    //TODO enable once passkeys fixed
-//    buttonRegisterPasskey.visibility = GONE
-    buttonRegisterPasskey.visibility = VISIBLE
+    if (isPasskeySupported()) {
+      buttonLoginPasskey.visibility = GONE
+      buttonRegisterPasskey.visibility = VISIBLE
+    }
     this.syncBookmarks.visibility = VISIBLE
     this.bookmarkStatement.visibility = VISIBLE
     this.bookmarkSyncProgress.visibility = INVISIBLE
@@ -301,10 +314,11 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private fun OnConfigureAccountLogoutFailed(loginState: AccountLoginState.AccountLogoutFailed) {
     buttonLogout.visibility = VISIBLE
     buttonLoginSuomiFi.visibility = GONE
-    buttonLoginPasskey.visibility = GONE
-    //TODO enable once passkeys fixed
-//    buttonRegisterPasskey.visibility = GONE
-    buttonRegisterPasskey.visibility = VISIBLE
+
+    if (isPasskeySupported()) {
+      buttonLoginPasskey.visibility = GONE
+      buttonRegisterPasskey.visibility = VISIBLE
+    }
   }
 
   private fun onTryRegisterPasskey() {
@@ -388,6 +402,55 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.viewModel.account.setLoginState(this.viewModel.account.loginState)
 
     this.subscriptions.clear()
+  }
+
+  private fun isPasskeySupported(): Boolean {
+    return android.os.Build.VERSION.SDK_INT >= 28
+  }
+
+  private fun reconfigureBookmarkSyncingSwitch(status: BookmarkSyncEnableStatus) {
+    /*
+     * Remove the checked-change listener, because setting `isChecked` will trigger the listener.
+     */
+
+    this.bookmarkSyncCheck.setOnCheckedChangeListener(null)
+
+    /*
+     * Otherwise, the switch is doing something that interests us...
+     */
+
+    val account = this.viewModel.account
+    return when (status) {
+      is BookmarkSyncEnableStatus.Changing -> {
+        this.bookmarkSyncProgress.visibility = View.VISIBLE
+        this.bookmarkSyncCheck.isEnabled = false
+      }
+
+      is BookmarkSyncEnableStatus.Idle -> {
+        this.bookmarkSyncProgress.visibility = View.INVISIBLE
+        this.logger.debug("Bookmark Syncing Status: $status")
+        when (status.status) {
+
+          BookmarkSyncEnableResult.SYNC_ENABLE_NOT_SUPPORTED -> {
+            this.bookmarkSyncCheck.isChecked = false
+            this.bookmarkSyncCheck.isEnabled = false
+          }
+
+          BookmarkSyncEnableResult.SYNC_ENABLED,
+          BookmarkSyncEnableResult.SYNC_DISABLED -> {
+            val isPermitted = account.preferences.bookmarkSyncingPermitted
+            val isSupported = account.loginState.credentials?.annotationsURI != null
+
+            this.bookmarkSyncCheck.isChecked = isPermitted
+            this.bookmarkSyncCheck.isEnabled = isSupported
+
+            this.bookmarkSyncCheck.setOnCheckedChangeListener { _, isChecked ->
+              this.viewModel.enableBookmarkSyncing(isChecked)
+            }
+          }
+        }
+      }
+    }
   }
 
 }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EkirjastoAccountViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EkirjastoAccountViewModel.kt
@@ -199,6 +199,7 @@ class EkirjastoAccountViewModel(
    */
 
   fun enableBookmarkSyncing(enabled: Boolean) {
+    this.logger.debug("EnableBookmarkSyncing: $enabled")
     this.bookmarkService.bookmarkSyncEnable(this.accountId, enabled)
   }
 

--- a/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
@@ -121,7 +121,7 @@
                     android:layout_marginTop="16dp"
                     android:layout_marginEnd="16dp"
                     android:layout_marginBottom="16dp"
-                    android:enabled="false"
+                    android:enabled="true"
                     android:label="@id/accountSyncBookmarksLabel"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"

--- a/simplified-ui-tutorial/src/main/java/org/librarysimplified/ui/login/LoginUiFragment.kt
+++ b/simplified-ui-tutorial/src/main/java/org/librarysimplified/ui/login/LoginUiFragment.kt
@@ -2,6 +2,7 @@ package org.librarysimplified.ui.login
 
 import android.os.Bundle
 import android.view.View
+import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.widget.Button
 import androidx.fragment.app.Fragment
@@ -19,13 +20,20 @@ class LoginUiFragment : Fragment(R.layout.login_fragment) {
     val loginPasskeyButton = view.findViewById<Button>(R.id.ekirjasto_loginPasskey)
     val loginSkipButton = view.findViewById<Button>(R.id.ekirjasto_loginSkip)
 
-    //TODO: Enable passkey buttons when fixed
-    loginPasskeyButton.visibility = VISIBLE
+    loginPasskeyButton.visibility = when (isPasskeySupported()) {
+      true -> VISIBLE
+      false -> GONE
+    }
 
     loginSuomiFiButton!!.setOnClickListener { loginSuomiFi() }
     loginPasskeyButton!!.setOnClickListener { loginPasskey() }
     loginSkipButton!!.setOnClickListener { skipLogin() }
   }
+
+  private fun isPasskeySupported(): Boolean {
+    return android.os.Build.VERSION.SDK_INT >= 28
+  }
+
   private fun skipLogin() {
     this.listener.post(LoginEvent.SkipLogin)
   }


### PR DESCRIPTION
Account fixes

**What's this do?**
- Passkeys buttons are visible only on API 28 or higher
- Finalized implementation of bookmark sync button

**Why are we doing this? (w/ JIRA link if applicable)**
[Quick blurb about why the code is needed and Jira link goes here / Do these changes meet the business requirements of the story?]

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Have you updated the changelog?**

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
