### PR TITLE
Change support email address (email address for sending error reports)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,6 +46,9 @@ ekirjasto.languages=en,fi,sv
 ekirjasto.liblcp.uri=https://liblcp.dita.digital
 ekirjasto.liblcp.repositorylayout=/[organisation]/[module]/android/aar/test/[revision].[ext]
 
+# Email address to send error reports to (the feedback form is handled differently)
+ekirjasto.supportEmail=e-kirjasto-tekniikka@helsinki.fi
+
 ekirjasto.testLogin.enabled=false
 # Circulation API and library provider ID to use when test login is active
 ekirjasto.testLogin.circulationApiUrl=https://lib-dev.e-kirjasto.fi

--- a/simplified-app-ekirjasto/build.gradle.kts
+++ b/simplified-app-ekirjasto/build.gradle.kts
@@ -151,6 +151,8 @@ android {
         println("Configured languages: $languages")
         resourceConfigurations += languages.split(",")
         setProperty("archivesBaseName", "ekirjasto")
+        val supportEmail = overrideProperty("ekirjasto.supportEmail")
+        buildConfigField("String", "SUPPORT_EMAIL", "\"$supportEmail\"")
     }
 
     /*

--- a/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoBuildConfigurationService.kt
+++ b/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoBuildConfigurationService.kt
@@ -1,6 +1,6 @@
 package fi.kansalliskirjasto.ekirjasto
 
-import org.librarysimplified.main.BuildConfig
+import org.librarysimplified.main.BuildConfig as MainBuildConfig
 import org.nypl.simplified.buildconfig.api.BuildConfigOAuthScheme
 import org.nypl.simplified.buildconfig.api.BuildConfigurationAccountsRegistryURIs
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
@@ -27,11 +27,11 @@ class EkirjastoBuildConfigurationService : BuildConfigurationServiceType {
   override val showBooksFromAllAccounts: Boolean
     get() = false
   override val vcsCommit: String
-    get() = BuildConfig.SIMPLIFIED_GIT_COMMIT
+    get() = MainBuildConfig.SIMPLIFIED_GIT_COMMIT
   override val simplifiedVersion: String
-    get() = BuildConfig.SIMPLIFIED_VERSION
+    get() = MainBuildConfig.SIMPLIFIED_VERSION
   override val supportErrorReportEmailAddress: String
-    get() = "support@ellibs.com"
+    get() = BuildConfig.SUPPORT_EMAIL
   override val supportErrorReportSubject: String
     get() = "[ekirjasto-error]"
   override val oauthCallbackScheme: BuildConfigOAuthScheme


### PR DESCRIPTION
Change the support email address from support@ellibs.com to e-kirjasto-tekniikka@helsinki.fi. Also moved defining the email address to gradle.properties, instead of hard-coding it in Kotlin code (this way it can be overridden in local.properties easily, if wanted).

Issue: [SIMPLYE-412](https://jira.lingsoft.fi/browse/SIMPLYE-412)
