### PR TITLE
Add extra url params to the feedback form

### DIFF
--- a/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
+++ b/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
@@ -3,6 +3,8 @@ package fi.kansalliskirjasto.ekirjasto
 import org.librarysimplified.documents.DocumentConfiguration
 import org.librarysimplified.documents.DocumentConfigurationServiceType
 import java.net.URI
+import android.os.Build
+import fi.kansalliskirjasto.ekirjasto.BuildConfig;
 
 @Suppress("RedundantNullableReturnType")
 class EkirjastoDocumentStoreConfiguration : DocumentConfigurationServiceType {
@@ -16,7 +18,7 @@ class EkirjastoDocumentStoreConfiguration : DocumentConfigurationServiceType {
   override val feedback: DocumentConfiguration? =
     DocumentConfiguration(
       name = null,
-      remoteURI = URI.create("https://lib.e-kirjasto.fi/palaute/?lang=__LANGUAGE__")
+      remoteURI = URI.create("https://lib.e-kirjasto.fi/palaute/?lang=__LANGUAGE__&device_model=${Build.MANUFACTURER}%20${Build.MODEL}&software_version=${BuildConfig.VERSION_NAME}%20(${BuildConfig.VERSION_CODE})")
     )
 
   override val accessibilityStatement: DocumentConfiguration? =


### PR DESCRIPTION
Adds extra url params for device model and software version.

Refs EKIR-191

**What's this do?**
Adds device model and software version to the url params when opening the feedback form.

**Why are we doing this? (w/ JIRA link if applicable)**
So that we know if feedback is still relevant and to confirm that multiple people with the same device have a problem (and manual input of the device models might result in nonspecific information like "iPhone" or "Android").

**How should this be tested? / Do these changes have associated tests?**
Checking that the server receives the url params for instance.

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
no

**Has the application documentation been updated for these changes?**
no

**Did someone actually run this code to verify it works?**
yes