### PR TITLE
Hotfix for crash when creating feedback form URL

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,6 +41,9 @@ ekirjasto.versionName=1.0.5
 # Useful when trying to find performance issues, but also makes for noisy logs
 ekirjasto.enableStrictMode=false
 
+# URL for the feedback form
+ekirjasto.feedbackUrlBase=https://lib.e-kirjasto.fi/palaute/
+
 ekirjasto.languages=en,fi,sv
 
 ekirjasto.liblcp.uri=https://liblcp.dita.digital

--- a/simplified-app-ekirjasto/build.gradle.kts
+++ b/simplified-app-ekirjasto/build.gradle.kts
@@ -147,6 +147,8 @@ android {
         applicationId = "fi.kansalliskirjasto.ekirjasto"
         versionName = getVersionName()
         versionCode = calculateVersionCode()
+        val feedbackUrlBase = overrideProperty("ekirjasto.feedbackUrlBase")
+        buildConfigField("String", "FEEDBACK_URL_BASE", "\"$feedbackUrlBase\"")
         val languages = overrideProperty("ekirjasto.languages")
         println("Configured languages: $languages")
         resourceConfigurations += languages.split(",")

--- a/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
+++ b/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
@@ -1,10 +1,11 @@
 package fi.kansalliskirjasto.ekirjasto
 
+import android.os.Build
+import java.net.URI
+import java.net.URLEncoder
 import org.librarysimplified.documents.DocumentConfiguration
 import org.librarysimplified.documents.DocumentConfigurationServiceType
-import java.net.URI
-import android.os.Build
-import fi.kansalliskirjasto.ekirjasto.BuildConfig;
+import org.librarysimplified.main.BuildConfig as MainBuildConfig
 
 @Suppress("RedundantNullableReturnType")
 class EkirjastoDocumentStoreConfiguration : DocumentConfigurationServiceType {
@@ -18,7 +19,7 @@ class EkirjastoDocumentStoreConfiguration : DocumentConfigurationServiceType {
   override val feedback: DocumentConfiguration? =
     DocumentConfiguration(
       name = null,
-      remoteURI = URI.create("https://lib.e-kirjasto.fi/palaute/?lang=__LANGUAGE__&device_model=${Build.MANUFACTURER}%20${Build.MODEL}&software_version=${BuildConfig.VERSION_NAME}%20(${BuildConfig.VERSION_CODE})")
+      remoteURI = URI.create(getFeedbackUrl())
     )
 
   override val accessibilityStatement: DocumentConfiguration? =
@@ -47,4 +48,15 @@ class EkirjastoDocumentStoreConfiguration : DocumentConfigurationServiceType {
       name = null,
       remoteURI = URI.create("https://www.kansalliskirjasto.fi/__LANGUAGE__/e-kirjasto/e-kirjaston-usein-kysytyt-kysymykset")
     )
+
+  private fun getFeedbackUrl(): String {
+    var url = BuildConfig.FEEDBACK_URL_BASE
+    url += "?lang=__LANGUAGE__"
+    url += "&device_manufacturer=${URLEncoder.encode(Build.MANUFACTURER, "UTF-8")}"
+    url += "&device_model=${URLEncoder.encode(Build.MODEL, "UTF-8")}"
+    url += "&version_name=${URLEncoder.encode(BuildConfig.VERSION_NAME, "UTF-8")}"
+    url += "&version_code=${URLEncoder.encode(BuildConfig.VERSION_CODE.toString(), "UTF-8")}"
+    url += "&commit=${URLEncoder.encode(MainBuildConfig.SIMPLIFIED_GIT_COMMIT, "UTF-8")}"
+    return url
+  }
 }

--- a/simplified-ekirjasto-util/build.gradle.kts
+++ b/simplified-ekirjasto-util/build.gradle.kts
@@ -59,7 +59,7 @@ fun getCurrentFlavor(): String {
         matcher.group(1).lowercase()
     }
     else {
-        println("WARNING: Could not find flavor")
+        println("WARNING: Could not find flavor (not a build task?)")
         ""
     }
 }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -183,7 +183,9 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     button.isEnabled = document != null
     if (document != null) {
       button.setOnClickListener {
-        var title = button.text
+        val title = button.text
+        val url = LanguageUtil.insertLanguageInURL(document.readableURL)
+        logger.debug("OpenDocViewer: {} -> {}", title, url)
         this.listener.post(
           AccountDetailEvent.OpenDocViewer(
             title = title.toString(),


### PR DESCRIPTION
If the feedback form URL had characters that are not legal in a URL, the app crashed during initialization.

Also moved the feedback URL "base" to gradle.properties, so that it can be easily overridden during development in local.properties.

And also split the "combined" URL parameters (manufacturer + model and version name + version code) into separate URL parameters, because the separator used (a space) could be problematic, since e.g. the manufacturer name can also contain a space.

And also and also added the Git commit as a URL parameter, since that would be useful for developers in addition to the other version info.