### PR TITLE
Bump version to 1.0.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ org.thepalaceproject.build.jdkBytecodeTarget=11
 org.thepalaceproject.build.jdkBuild=17
 org.thepalaceproject.build.publishSources=true
 
-ekirjasto.versionName=1.0.5
+ekirjasto.versionName=1.0.6
 
 # If true, enable StrictMode checking in debug builds
 # Useful when trying to find performance issues, but also makes for noisy logs


### PR DESCRIPTION
Version bump in preparation for a new production release (hotfix with https://github.com/NatLibFi/ekirjasto-android-core/pull/125).