### PR TITLE
Base64 encode the support email address to prevent spam bot scraping

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -57,8 +57,9 @@ ekirjasto.storePassword=storePassword
 ekirjasto.keyPassword=keyPassword
 ekirjasto.keyAlias=key0
 
-# Email address to send error reports to (the feedback form is handled differently)
-ekirjasto.supportEmail=e-kirjasto-tekniikka@helsinki.fi
+# Email address for error reports (the feedback form is handled differently)
+# Encoded as base64, to prevent scraping the email address from the public repo
+ekirjasto.supportEmailBase64=ZS1raXJqYXN0by10ZWtuaWlra2FAaGVsc2lua2kuZmk=
 
 ekirjasto.testLogin.enabled=false
 # Circulation API and library provider ID to use when test login is active

--- a/simplified-app-ekirjasto/build.gradle.kts
+++ b/simplified-app-ekirjasto/build.gradle.kts
@@ -2,6 +2,7 @@ import java.io.FileInputStream
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
+import java.util.Base64
 import java.util.Properties
 
 fun calculateVersionCode(): Int {
@@ -165,7 +166,9 @@ android {
         println("Configured languages: $languages")
         resourceConfigurations += languages.split(",")
         setProperty("archivesBaseName", "ekirjasto")
-        val supportEmail = overrideProperty("ekirjasto.supportEmail")
+        val supportEmailBase64 = overrideProperty("ekirjasto.supportEmailBase64")
+        val supportEmail = Base64.getDecoder().decode(supportEmailBase64.toByteArray(Charsets.UTF_8)).toString(Charsets.UTF_8)
+        println("Support email: $supportEmail")
         buildConfigField("String", "SUPPORT_EMAIL", "\"$supportEmail\"")
     }
 


### PR DESCRIPTION
Encode the support email address as base64, to prevent scraping the email address from the public repo. This might not stop some smarter bots, but probably prevents most of them without adding too much complexity to the build process.