### PR TITLE
Obfuscate secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ First, set values like these in `local.properties`:
 ```
 ekirjasto.testLogin.enabled=true
 ekirjasto.testLogin.username=TestUser
-ekirjasto.testLogin.pinCode=1234567890
+ekirjasto.testLogin.pin.base64=MTIzNDU2Nzg5MA==
 ```
 
 Then, after closing the app (it cannot be open in the background),

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,11 +62,15 @@ ekirjasto.keyAlias=key0
 ekirjasto.supportEmailBase64=ZS1raXJqYXN0by10ZWtuaWlra2FAaGVsc2lua2kuZmk=
 
 ekirjasto.testLogin.enabled=false
+ekirjasto.testLogin.username=
+ekirjasto.testLogin.pin.base64=
 # Circulation API and library provider ID to use when test login is active
 ekirjasto.testLogin.circulationApiUrl=https://lib-dev.e-kirjasto.fi
 ekirjasto.testLogin.libraryProviderId=28bed937-a16b-4d69-a9c8-4b2656333423
 
 # Set this in local.properties
+transifex.token.base64=
+# Set this in local.properties (only used by transifex.sh)
 transifex.token=
 # Set this in local.properties (only used by transifex.sh)
 transifex.secret=

--- a/local.properties.example
+++ b/local.properties.example
@@ -6,13 +6,14 @@ ekirjasto.keyalias=key0
 # Change "test" below with the liblcp AAR secret path
 ekirjasto.liblcp.repositorylayout=/[organisation]/[module]/android/aar/test/[revision].[ext]
 
-# Set test login username and PIN code here (for Google Play review)
+# Set test login username and PIN code (base64 encoded) for Google Play review
 ekirjasto.testLogin.enabled=true
 ekirjasto.testLogin.username=
-ekirjasto.testLogin.pinCode=
+ekirjasto.testLogin.pin.base64=
 
-# Add the Transifex token here (required for release builds)
+# Add the base64 encoded Transifex token here
+transifex.token.base64=
+# Optionally, add the Transifex token here (only used by transifex.sh)
 transifex.token=
 # Optionally, add the Transifex secret here (only used by transifex.sh)
 transifex.secret=
-

--- a/simplified-ekirjasto-testing-ui/build.gradle.kts
+++ b/simplified-ekirjasto-testing-ui/build.gradle.kts
@@ -42,8 +42,6 @@ android {
         buildConfigField("Boolean", "TEST_LOGIN_ENABLED", testLoginEnabled)
         val testLoginUsername = overridePropertyDefault("ekirjasto.testLogin.username", "")
         buildConfigField("String", "TEST_LOGIN_USERNAME", "\"$testLoginUsername\"")
-        val testLoginPinCode = overridePropertyDefault("ekirjasto.testLogin.pinCode", "")
-        buildConfigField("String", "TEST_LOGIN_PIN_CODE", "\"$testLoginPinCode\"")
     }
 }
 

--- a/simplified-ekirjasto-testing-ui/src/main/java/fi/kansalliskirjasto/ekirjasto/testing/ui/TestLoginFragment.kt
+++ b/simplified-ekirjasto-testing-ui/src/main/java/fi/kansalliskirjasto/ekirjasto/testing/ui/TestLoginFragment.kt
@@ -17,6 +17,7 @@ import androidx.fragment.app.Fragment
 import fi.ekirjasto.testing.ui.BuildConfig
 import fi.ekirjasto.testing.ui.R
 import fi.kansalliskirjasto.ekirjasto.util.DataUtil
+import fi.kansalliskirjasto.ekirjasto.util.SecretsUtil
 import fi.kansalliskirjasto.ekirjasto.testing.TestingOverrides
 import org.nypl.simplified.android.ktx.supportActionBar
 import org.slf4j.LoggerFactory
@@ -138,7 +139,7 @@ class TestLoginFragment(
     val inputPin = pinInput.text.toString()
 
     val correctUserName = BuildConfig.TEST_LOGIN_USERNAME
-    val correctPin = BuildConfig.TEST_LOGIN_PIN_CODE
+    val correctPin = SecretsUtil.getTestLoginPin()
     if ((correctUserName.lowercase() == inputUsername.lowercase())
         && (correctPin.lowercase() == inputPin.lowercase())) {
       logger.info("Correct login")

--- a/simplified-ekirjasto-util/build.gradle.kts
+++ b/simplified-ekirjasto-util/build.gradle.kts
@@ -77,12 +77,14 @@ android {
         buildConfigField("String", "FLAVOR", "\"$buildFlavor\"")
         val languages = overrideProperty("ekirjasto.languages")
         buildConfigField("String", "LANGUAGES", "\"$languages\"")
+        val testLoginPinBase64 = overridePropertyDefault("ekirjasto.testLogin.pin.base64", "")
+        buildConfigField("String", "TEST_LOGIN_PIN_BASE64", "\"$testLoginPinBase64\"")
+        val transifexTokenBase64 = overrideProperty("transifex.token.base64")
+        buildConfigField("String", "TRANSIFEX_TOKEN_BASE64", "\"$transifexTokenBase64\"")
     }
 }
 
 dependencies {
-    //implementation(project(":simplified-webview"))
-
     implementation(libs.androidx.activity)
     implementation(libs.androidx.annotation)
     implementation(libs.androidx.appcompat)

--- a/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/SecretsUtil.kt
+++ b/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/SecretsUtil.kt
@@ -1,0 +1,43 @@
+package fi.kansalliskirjasto.ekirjasto.util
+
+import android.util.Base64
+import android.util.Log
+import fi.ekirjasto.util.BuildConfig
+
+/**
+ * Secrets related utilities.
+ *
+ * The purpose of this class is to obfuscate the secrets used in the app,
+ * although it's not really possible to completely hide client-side secrets.
+ *
+ * TODO: Use something more complex than just base64 encoding here.
+ */
+sealed class SecretsUtil {
+  companion object {
+    /**
+     * Decode a base64 encoded string
+     */
+    private fun base64Decode(input: String): String {
+      if (input.isBlank()) {
+        return ""
+      }
+
+      val data = Base64.decode(input, Base64.DEFAULT)
+      return String(data, Charsets.UTF_8)
+    }
+
+    /**
+     * Get the test login PIN code.
+     */
+    fun getTestLoginPin(): String {
+      return base64Decode(BuildConfig.TEST_LOGIN_PIN_BASE64)
+    }
+
+    /**
+     * Get the Transifex token.
+     */
+    fun getTransifexToken(): String {
+      return base64Decode(BuildConfig.TRANSIFEX_TOKEN_BASE64)
+    }
+  }
+}

--- a/simplified-main/build.gradle.kts
+++ b/simplified-main/build.gradle.kts
@@ -42,8 +42,6 @@ android {
         buildConfigField("String", "LANGUAGES", "\"$languages\"")
         val enableStrictMode = overrideProperty("ekirjasto.enableStrictMode")
         buildConfigField("Boolean", "ENABLE_STRICT_MODE", enableStrictMode)
-        val transifexToken = overrideProperty("transifex.token")
-        buildConfigField("String", "TRANSIFEX_TOKEN", "\"$transifexToken\"")
     }
 }
 

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainTransifex.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainTransifex.kt
@@ -4,16 +4,17 @@ import android.content.Context
 import com.transifex.txnative.LocaleState
 import com.transifex.txnative.TxNative
 import com.transifex.txnative.missingpolicy.WrappedStringPolicy
-import org.slf4j.LoggerFactory
+import fi.kansalliskirjasto.ekirjasto.util.SecretsUtil
 import java.io.FileNotFoundException
 import java.util.Properties
+import org.slf4j.LoggerFactory
+
 
 /**
  * Functions to enable Transifex string translation.
  */
 
 object MainTransifex {
-
   private val logger = LoggerFactory.getLogger(MainTransifex::class.java)
 
   /**
@@ -24,7 +25,8 @@ object MainTransifex {
   @Suppress("KotlinConstantConditions")
   fun configure(applicationContext: Context) {
     this.logger.debug("MainTransifex.configure()")
-    if (BuildConfig.TRANSIFEX_TOKEN == "") {
+    val transifexToken = SecretsUtil.getTransifexToken()
+    if (transifexToken.isBlank()) {
       logger.warn("Transifex token not set, Transifex will only use cached localizations")
     }
 
@@ -50,7 +52,7 @@ object MainTransifex {
     TxNative.init(
       applicationContext,
       localeState,
-      BuildConfig.TRANSIFEX_TOKEN,
+      transifexToken,
       null,
       null,
       stringPolicy


### PR DESCRIPTION
It's impossible to completely hide secrets in a client application, but at least we can make it a bit more difficult to see them.

Palace had them in an asset file, so it was enough to just extract the APK, and you could see all secrets handily in one file. With the way secrets are stored here, you would need to decompile the code, find strings, and decode those into the secrets.

This makes it a bit more difficult, but still not impossible (it's impossible to make it impossible, if the secrets are stored client-side). The current method could definitely still be improved, I have a few ideas on how to do that.
