### PR TITLE
Ekir 185 add language choice to settings with reload

### DIFF
--- a/simplified-ekirjasto-magazines/src/main/java/fi/kansalliskirjasto/ekirjasto/magazines/MagazinesFragment.kt
+++ b/simplified-ekirjasto-magazines/src/main/java/fi/kansalliskirjasto/ekirjasto/magazines/MagazinesFragment.kt
@@ -207,7 +207,7 @@ class MagazinesFragment : Fragment(R.layout.magazines) {
   private fun getBrowsingUrlBase(): String? {
     val magazineServiceUrl = viewModel.getMagazineServiceUrl() ?: return null
     // Get the language to use and load the magazine collection browser
-    val language = LanguageUtil.getUserLanguage()
+    val language = LanguageUtil.getUserLanguage(this.requireContext())
     return "$magazineServiceUrl/$language"
   }
 

--- a/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/LanguageUtil.kt
+++ b/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/LanguageUtil.kt
@@ -4,6 +4,7 @@ import android.content.res.Resources
 import fi.ekirjasto.util.BuildConfig
 import java.net.URI
 import java.net.URL
+import java.util.Locale
 
 /**
  * Language and localization related utilities.
@@ -21,8 +22,10 @@ sealed class LanguageUtil {
       val userLanguages = Resources.getSystem().configuration.locales.toLanguageTags().split(",")
         // Get only the language from the language tag (e.g. "en" from "en-US")
         .map { it.split("-")[0] }
+      //Get user language from locale, which is set by the locale helper
+      val userLanguage = Locale.getDefault().language
       // Get the first user language that is one of the app's supported languages, or default to "en"
-      return userLanguages.firstOrNull{ appLanguages.contains(it) } ?: "en"
+      return userLanguage//userLanguages.firstOrNull{ appLanguages.contains(it) } ?: "en"
     }
 
     /**

--- a/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/LanguageUtil.kt
+++ b/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/LanguageUtil.kt
@@ -1,5 +1,6 @@
 package fi.kansalliskirjasto.ekirjasto.util
 
+import android.content.Context
 import android.content.res.Resources
 import fi.ekirjasto.util.BuildConfig
 import java.net.URI
@@ -14,25 +15,17 @@ sealed class LanguageUtil {
     /**
      * Get the user's language.
      */
-    fun getUserLanguage(): String {
-      // Get the list of languages supported by the app
-      val appLanguages = BuildConfig.LANGUAGES.split(",")
-      // Get the list of languages that the user has set for their device
-      // LocaleList cannot give you an actual *list*, so convert to a string and split into a list
-      val userLanguages = Resources.getSystem().configuration.locales.toLanguageTags().split(",")
-        // Get only the language from the language tag (e.g. "en" from "en-US")
-        .map { it.split("-")[0] }
-      //Get user language from locale, which is set by the locale helper
-      val userLanguage = Locale.getDefault().language
-      // Get the first user language that is one of the app's supported languages, or default to "en"
-      return userLanguage//userLanguages.firstOrNull{ appLanguages.contains(it) } ?: "en"
+    fun getUserLanguage(context: Context): String {
+      //Get user language from LocaleHelper
+      val userLanguage = LocaleHelper.getLanguage(context)
+      return userLanguage
     }
 
     /**
      * Insert the user's language to a URI.
      */
-    fun insertLanguageInURL(url: URL): URL {
-      val language = getUserLanguage()
+    fun insertLanguageInURL(url: URL, context: Context): URL {
+      val language = LocaleHelper.getLanguage(context)
       val urlString = url.toString().replace("__LANGUAGE__", language)
       return URI.create(urlString).toURL()
     }

--- a/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/LocaleHelper.java
+++ b/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/LocaleHelper.java
@@ -6,62 +6,90 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
-import android.preference.PreferenceManager;
-
 import java.util.Locale;
 
+/**
+ * Util class for handling in-app language changes
+ */
 public class LocaleHelper {
 
-  private static final String SELECTED_LANGUAGE = "Locale.Helper.Selected.Language";
+  private static final String SELECTED_LANGUAGE = "selected_language";
 
-  // the method is used to set the language at runtime, set the language currently
-  // in Locale
+  /**
+   * Function is used to set the language at runtime, sets the language currently
+   * in cache
+   * @param context The base context
+   * @return Context
+   */
   public static Context onAttach(Context context) {
     String lang = getPersistedData(context, Locale.getDefault().getLanguage());
     return setLocale(context, lang);
   }
 
-  // the method is used to set the language at runtime, set the language given as an argument
+  /**
+   * Function used to set given language at runtime, set the language given as an argument
+   * if no other value has been given before, otherwise return the currently set language
+   * @param context The base context
+   * @param defaultLanguage Language to use if no language in cache
+   * @return Context
+   */
   public static Context onAttach(Context context, String defaultLanguage) {
     String lang = getPersistedData(context, defaultLanguage);
     return setLocale(context, lang);
   }
 
-  // return the current set language
-  public static String getLanguage(Context context) {
-    return getPersistedData(context, Locale.getDefault().getLanguage());
-  }
-
-  // place the chosen language as the locale, method is based on version
+  /**
+   * Place chosen language as locale
+   * @param context The base context
+   * @param language Language as string
+   * @return Context
+   */
+  //
   public static Context setLocale(Context context, String language) {
     persist(context, language);
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      return updateResources(context, language);
-    }
-
-    return updateResourcesLegacy(context, language);
+    return updateResources(context, language);
   }
 
-  // Returns the data currently set as the language
+  //
+
+  /**
+   * Return language in cache, if not set return default language
+   * @param context The base context
+   * @param defaultLanguage Language tag
+   * @return String
+   */
   private static String getPersistedData(Context context, String defaultLanguage) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    SharedPreferences preferences = context.getSharedPreferences("APP_PREFERENCES", Context.MODE_PRIVATE);
     return preferences.getString(SELECTED_LANGUAGE, defaultLanguage);
   }
 
-  // add the given language to persistent memory, where it remains until set again or the
-  // app cache is cleared
+
+
+  /**
+   * Add given language to cache, where it remains until set again or the
+   * app cache is cleared
+   * @param context The base context
+   * @param language Language tag
+   */
   private static void persist(Context context, String language) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    SharedPreferences preferences = context.getSharedPreferences("APP_PREFERENCES", Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = preferences.edit();
 
     editor.putString(SELECTED_LANGUAGE, language);
     editor.apply();
   }
 
-  // the method is used update the language of application by creating a
-  // Locale object setting it as the default, and setting it into resources
-  @TargetApi(Build.VERSION_CODES.N)
+
+
+  /**
+   * Function used to update the language of application by creating a
+   * Locale object setting it as the default, and setting it into resources.
+   * Returns base context as we restart app to apply changes, and thus
+   * the base context is sufficient, using createConfigurationContext breaks dark mode.
+   * @param context The base context
+   * @param language Language tag
+   * @return Context
+   */
   private static Context updateResources(Context context, String language) {
     Locale locale = new Locale(language);
     Locale.setDefault(locale);
@@ -70,26 +98,15 @@ public class LocaleHelper {
     configuration.setLocale(locale);
     configuration.setLayoutDirection(locale);
 
-    return context.createConfigurationContext(configuration);
+    return context;
   }
 
-  // update the language on older devices by creating
-  // Locale object setting it as the default, and setting it into resources
-  @SuppressWarnings("deprecation")
-  private static Context updateResourcesLegacy(Context context, String language) {
-    Locale locale = new Locale(language);
-    Locale.setDefault(locale);
-
-    Resources resources = context.getResources();
-
-    Configuration configuration = resources.getConfiguration();
-    configuration.locale = locale;
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      configuration.setLayoutDirection(locale);
-    }
-
-    resources.updateConfiguration(configuration, resources.getDisplayMetrics());
-
-    return context;
+  /**
+   * Return current language, returns the language in locale if not set
+   * @param context The base context
+   * @return String language tag
+   */
+  public static String getLanguage(Context context) {
+    return getPersistedData(context, Locale.getDefault().getLanguage());
   }
 }

--- a/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/LocaleHelper.java
+++ b/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/LocaleHelper.java
@@ -1,0 +1,95 @@
+package fi.kansalliskirjasto.ekirjasto.util;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Build;
+import android.preference.PreferenceManager;
+
+import java.util.Locale;
+
+public class LocaleHelper {
+
+  private static final String SELECTED_LANGUAGE = "Locale.Helper.Selected.Language";
+
+  // the method is used to set the language at runtime, set the language currently
+  // in Locale
+  public static Context onAttach(Context context) {
+    String lang = getPersistedData(context, Locale.getDefault().getLanguage());
+    return setLocale(context, lang);
+  }
+
+  // the method is used to set the language at runtime, set the language given as an argument
+  public static Context onAttach(Context context, String defaultLanguage) {
+    String lang = getPersistedData(context, defaultLanguage);
+    return setLocale(context, lang);
+  }
+
+  // return the current set language
+  public static String getLanguage(Context context) {
+    return getPersistedData(context, Locale.getDefault().getLanguage());
+  }
+
+  // place the chosen language as the locale, method is based on version
+  public static Context setLocale(Context context, String language) {
+    persist(context, language);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      return updateResources(context, language);
+    }
+
+    return updateResourcesLegacy(context, language);
+  }
+
+  // Returns the data currently set as the language
+  private static String getPersistedData(Context context, String defaultLanguage) {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    return preferences.getString(SELECTED_LANGUAGE, defaultLanguage);
+  }
+
+  // add the given language to persistent memory, where it remains until set again or the
+  // app cache is cleared
+  private static void persist(Context context, String language) {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    SharedPreferences.Editor editor = preferences.edit();
+
+    editor.putString(SELECTED_LANGUAGE, language);
+    editor.apply();
+  }
+
+  // the method is used update the language of application by creating a
+  // Locale object setting it as the default, and setting it into resources
+  @TargetApi(Build.VERSION_CODES.N)
+  private static Context updateResources(Context context, String language) {
+    Locale locale = new Locale(language);
+    Locale.setDefault(locale);
+
+    Configuration configuration = context.getResources().getConfiguration();
+    configuration.setLocale(locale);
+    configuration.setLayoutDirection(locale);
+
+    return context.createConfigurationContext(configuration);
+  }
+
+  // update the language on older devices by creating
+  // Locale object setting it as the default, and setting it into resources
+  @SuppressWarnings("deprecation")
+  private static Context updateResourcesLegacy(Context context, String language) {
+    Locale locale = new Locale(language);
+    Locale.setDefault(locale);
+
+    Resources resources = context.getResources();
+
+    Configuration configuration = resources.getConfiguration();
+    configuration.locale = locale;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      configuration.setLayoutDirection(locale);
+    }
+
+    resources.updateConfiguration(configuration, resources.getDisplayMetrics());
+
+    return context;
+  }
+}

--- a/simplified-main/src/main/java/org/librarysimplified/main/CustomHTTPInterceptors.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/CustomHTTPInterceptors.kt
@@ -2,6 +2,7 @@ package org.librarysimplified.main
 
 import android.content.Context
 import android.content.res.Resources
+import fi.kansalliskirjasto.ekirjasto.util.LocaleHelper
 import okhttp3.Interceptor
 import okhttp3.Response
 import org.librarysimplified.http.vanilla.extensions.LSHTTPInterceptorFactoryType
@@ -16,12 +17,13 @@ class CustomHTTPInterceptors {
     override val version: String = "1.0.0"
 
     override fun createInterceptor(context: Context): Interceptor {
-      return AcceptLanguage()
+      return AcceptLanguage(context)
     }
   }
 
-  class AcceptLanguage : Interceptor {
+  class AcceptLanguage(cont: Context) : Interceptor {
     private val logger = LoggerFactory.getLogger(AcceptLanguage::class.java)
+    private val context = cont
 
     override fun intercept(chain: Interceptor.Chain): Response {
       val acceptLanguageHeader = getAcceptLanguageHeader()
@@ -33,26 +35,13 @@ class CustomHTTPInterceptors {
     }
 
     private fun getAcceptLanguageHeader(): String {
-      //Get current language from Locale, the current language being .getDefault()
-      val languageTag = Locale.getDefault().language
+      //Get current language from LocaleHelper
+      val languageTag = LocaleHelper.getLanguage(context)
       // According to RFC2616, quality must be in the range 0-1 and have at most 3 decimal digits,
       // so let's start at 1.000
-      var quality = 1.000
-      val acceptLanguageHeader ="$languageTag;q=" + String.format(Locale.ENGLISH, "%.3f", quality)
-
-
-      // LocaleList cannot give you an actual *list*, so convert to a string and split into a list
-      //val languageTags = Resources.getSystem().configuration.locales.toLanguageTags().split(",")
-      // According to RFC2616, quality must be in the range 0-1 and have at most 3 decimal digits,
-      // so let's start at 1.000 and go down by 0.001 after every language tag
-      //var quality = 1.000
-      //val acceptLanguageHeader = languageTags.fold(""){ accumulator, langTag ->
-        // Java (or Kotlin here) is always so *succinct*
-      //  val langTagWithQ = "$langTag;q=" + String.format(Locale.ENGLISH, "%.3f", quality)
-        quality = max(0.001, quality - 0.001)
-      //  if (accumulator.isEmpty()) langTagWithQ else "$accumulator, $langTagWithQ"
-      //}
-      return acceptLanguageHeader //return acceptLanguageHeader
+      val quality = 1.000
+      val acceptLanguageHeader ="$languageTag;q=" + String.format(Locale.getDefault(), "%.3f", quality)
+      return acceptLanguageHeader
     }
   }
 }

--- a/simplified-main/src/main/java/org/librarysimplified/main/CustomHTTPInterceptors.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/CustomHTTPInterceptors.kt
@@ -33,19 +33,26 @@ class CustomHTTPInterceptors {
     }
 
     private fun getAcceptLanguageHeader(): String {
+      //Get current language from Locale, the current language being .getDefault()
+      val languageTag = Locale.getDefault().language
+      // According to RFC2616, quality must be in the range 0-1 and have at most 3 decimal digits,
+      // so let's start at 1.000
+      var quality = 1.000
+      val acceptLanguageHeader ="$languageTag;q=" + String.format(Locale.ENGLISH, "%.3f", quality)
+
+
       // LocaleList cannot give you an actual *list*, so convert to a string and split into a list
-      val languageTags = Resources.getSystem().configuration.locales.toLanguageTags().split(",")
+      //val languageTags = Resources.getSystem().configuration.locales.toLanguageTags().split(",")
       // According to RFC2616, quality must be in the range 0-1 and have at most 3 decimal digits,
       // so let's start at 1.000 and go down by 0.001 after every language tag
-      var quality = 1.000
-      val acceptLanguageHeader = languageTags.fold(""){ accumulator, langTag ->
+      //var quality = 1.000
+      //val acceptLanguageHeader = languageTags.fold(""){ accumulator, langTag ->
         // Java (or Kotlin here) is always so *succinct*
-        val langTagWithQ = "$langTag;q=" + String.format(Locale.ENGLISH, "%.3f", quality)
+      //  val langTagWithQ = "$langTag;q=" + String.format(Locale.ENGLISH, "%.3f", quality)
         quality = max(0.001, quality - 0.001)
-        if (accumulator.isEmpty()) langTagWithQ else "$accumulator, $langTagWithQ"
-      }
-
-      return acceptLanguageHeader
+      //  if (accumulator.isEmpty()) langTagWithQ else "$accumulator, $langTagWithQ"
+      //}
+      return acceptLanguageHeader //return acceptLanguageHeader
     }
   }
 }

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
@@ -2,6 +2,7 @@ package org.librarysimplified.main
 
 import android.Manifest
 import android.app.ActionBar
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -18,6 +19,7 @@ import com.google.firebase.dynamiclinks.FirebaseDynamicLinks
 import com.google.firebase.dynamiclinks.PendingDynamicLinkData
 import com.transifex.txnative.TxNative
 import fi.kansalliskirjasto.ekirjasto.testing.ui.TestLoginFragment
+import fi.kansalliskirjasto.ekirjasto.util.LocaleHelper
 import org.librarysimplified.services.api.Services
 import org.librarysimplified.ui.login.LoginMainFragment
 import org.librarysimplified.ui.onboarding.OnboardingEvent
@@ -58,6 +60,10 @@ class MainActivity : AppCompatActivity(R.layout.main_host) {
 
   private val defaultViewModelFactory: ViewModelProvider.Factory by lazy {
     MainActivityDefaultViewModelFactory(super.defaultViewModelProviderFactory)
+  }
+
+  override fun attachBaseContext(newBase: Context?) {
+    super.attachBaseContext(LocaleHelper.onAttach(newBase))
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainApplication.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainApplication.kt
@@ -1,6 +1,7 @@
 package org.librarysimplified.main
 
 import android.app.Application
+import android.content.Context
 import android.net.http.HttpResponseCache
 import android.os.Process
 import android.os.StrictMode
@@ -10,6 +11,7 @@ import androidx.core.content.pm.PackageInfoCompat
 import fi.kansalliskirjasto.ekirjasto.testing.TestingOverrides
 import fi.kansalliskirjasto.ekirjasto.util.AppInfoUtil
 import fi.kansalliskirjasto.ekirjasto.util.DataUtil
+import fi.kansalliskirjasto.ekirjasto.util.LocaleHelper
 import io.reactivex.Observable
 import org.librarysimplified.services.api.ServiceDirectoryType
 import org.nypl.simplified.boot.api.BootEvent
@@ -39,7 +41,9 @@ class MainApplication : Application() {
       },
       bootStringResources = ::MainServicesStrings
     )
-
+  override fun attachBaseContext(base: Context?) {
+    super.attachBaseContext(LocaleHelper.onAttach(base,"fi"))
+  }
   override fun onCreate() {
     super.onCreate()
 

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -37,8 +37,6 @@ import org.nypl.simplified.ui.accounts.AccountFragmentParameters
 import org.nypl.simplified.ui.accounts.ekirjasto.suomifi.EkirjastoLoginMethod
 import org.slf4j.LoggerFactory
 import org.thepalaceproject.theme.core.PalaceToolbar
-import java.net.URI
-import java.net.URL
 
 class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private val logger =
@@ -195,31 +193,6 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.reconfigureAccountUI()
   }
 
-  // Call to update the language
-  private fun updateLanguage(language : String) {
-    val cont = LocaleHelper.setLocale(requireContext(), language)
-    val res = cont.resources
-    logger.debug(res.toString())
-  }
-
-  // Show a popup asking if they want to set the language, and inform about restart
-  private fun popUp (lang: String) {
-    val builder: AlertDialog.Builder = AlertDialog.Builder(this.requireContext())
-    builder
-      .setMessage(R.string.restartPopupMessage)
-      .setTitle(R.string.restartPopupTitle)
-      .setPositiveButton(R.string.restartPopupAgree) { dialog, which ->
-        updateLanguage(lang)
-        DataUtil.restartApp(this.requireContext())
-      }
-      .setNegativeButton(R.string.restartPopupCancel) { dialog, which ->
-        //do nothing
-      }
-
-    val dialog: AlertDialog = builder.create()
-    dialog.show()
-  }
-
   private fun configureDocViewButton(button: Button, document: DocumentType?){
     button.isEnabled = document != null
     if (document != null) {
@@ -228,7 +201,7 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
         this.listener.post(
           AccountDetailEvent.OpenDocViewer(
             title = title.toString(),
-            url = LanguageUtil.insertLanguageInURL(document.readableURL)
+            url = LanguageUtil.insertLanguageInURL(document.readableURL, this.requireContext())
           )
         )
       }
@@ -436,4 +409,26 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.subscriptions.clear()
   }
 
+  // Show a popup asking if user wants to set chosen language, and inform about restart
+  private fun popUp (language: String) {
+    val builder: AlertDialog.Builder = AlertDialog.Builder(this.requireContext())
+    builder
+      .setMessage(R.string.restartPopupMessage)
+      .setTitle(R.string.restartPopupTitle)
+      .setPositiveButton(R.string.restartPopupAgree) { dialog, which ->
+        updateLanguageAndRestart(language)
+      }
+      .setNegativeButton(R.string.restartPopupCancel) { dialog, which ->
+        //do nothing
+      }
+
+    val dialog: AlertDialog = builder.create()
+    dialog.show()
+  }
+
+  // Call to update the language and restart
+  private fun updateLanguageAndRestart(language : String) {
+    LocaleHelper.setLocale(this.requireContext(), language)
+    DataUtil.restartApp(this.requireContext())
+  }
 }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -8,12 +8,15 @@ import android.view.View.VISIBLE
 import android.widget.Button
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SwitchCompat
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import fi.kansalliskirjasto.ekirjasto.util.DataUtil
 import fi.kansalliskirjasto.ekirjasto.util.LanguageUtil
+import fi.kansalliskirjasto.ekirjasto.util.LocaleHelper
 import io.reactivex.disposables.CompositeDisposable
 import org.librarysimplified.documents.DocumentType
 import org.librarysimplified.services.api.Services
@@ -74,6 +77,9 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private lateinit var buttonAccessibilityStatement: Button
   private lateinit var buttonLicenses: Button
   private lateinit var buttonFaq: Button
+  private lateinit var buttonEnglish: Button
+  private lateinit var buttonFinnish: Button
+  private lateinit var buttonSwedish: Button
   private lateinit var versionText: TextView
   private lateinit var bookmarkSyncProgress: ProgressBar
   private lateinit var bookmarkSyncCheck: SwitchCompat
@@ -114,6 +120,9 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.buttonUserAgreement = view.findViewById(R.id.buttonUserAgreement)
     this.buttonLicenses = view.findViewById(R.id.buttonLicenses)
     this.buttonFaq = view.findViewById(R.id.buttonFaq)
+    this.buttonEnglish = view.findViewById(R.id.buttonEnglish)
+    this.buttonFinnish = view.findViewById(R.id.buttonFinnish)
+    this.buttonSwedish = view.findViewById(R.id.buttonSwedish)
     this.versionText = view.findViewById(R.id.appVersion)
 
 
@@ -148,6 +157,18 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
       this.logger.debug("Register Passkey clicked")
       onTryRegisterPasskey()
     }
+    this.buttonEnglish.setOnClickListener {
+      this.logger.debug("English button clicked")
+      popUp("en")
+    }
+    this.buttonFinnish.setOnClickListener {
+      this.logger.debug("Finnish button clicked")
+      popUp("fi")
+    }
+    this.buttonSwedish.setOnClickListener {
+      this.logger.debug("Swedish button clicked")
+      popUp("sv")
+    }
 
 
     /*
@@ -172,6 +193,31 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
      */
 
     this.reconfigureAccountUI()
+  }
+
+  // Call to update the language
+  private fun updateLanguage(language : String) {
+    val cont = LocaleHelper.setLocale(requireContext(), language)
+    val res = cont.resources
+    logger.debug(res.toString())
+  }
+
+  // Show a popup asking if they want to set the language, and inform about restart
+  private fun popUp (lang: String) {
+    val builder: AlertDialog.Builder = AlertDialog.Builder(this.requireContext())
+    builder
+      .setMessage(R.string.restartPopupMessage)
+      .setTitle(R.string.restartPopupTitle)
+      .setPositiveButton(R.string.restartPopupAgree) { dialog, which ->
+        updateLanguage(lang)
+        DataUtil.restartApp(this.requireContext())
+      }
+      .setNegativeButton(R.string.restartPopupCancel) { dialog, which ->
+        //do nothing
+      }
+
+    val dialog: AlertDialog = builder.create()
+    dialog.show()
   }
 
   private fun configureDocViewButton(button: Button, document: DocumentType?){

--- a/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
@@ -151,6 +151,38 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/accountTop">
 
+            <TextView
+                android:id="@+id/accountLanguageChoiceText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/account_application_languages" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/buttonFinnish"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/buttonTextFinnish" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/buttonSwedish"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/buttonTextSwedish" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/buttonEnglish"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/buttonTextEnglish" />
+            </LinearLayout>
+
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonFaq"
                 style="@style/Palace.Button.Outlined.Settings"

--- a/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
@@ -37,28 +37,28 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonLogout"
-                style="@style/Palace.Button.Outlined.Settings"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/accountLogout" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonLoginSuomiFi"
-                style="@style/Palace.Button.Outlined.Settings"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/account_login_suomifi" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonLoginPasskey"
-                style="@style/Palace.Button.Outlined.Settings"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/account_login_passkey" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonRegisterPasskey"
-                style="@style/Palace.Button.Outlined.Settings"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/account_register_passkey" />
@@ -153,6 +153,7 @@
 
             <TextView
                 android:id="@+id/accountLanguageChoiceText"
+                style="@style/Palace.TextViewStyle.Settings.Dark"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/account_application_languages" />
@@ -163,6 +164,7 @@
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/buttonFinnish"
+                    style="@style/Palace.Button.Outlined.Settings"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -170,6 +172,7 @@
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/buttonSwedish"
+                    style="@style/Palace.Button.Outlined.Settings"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -177,6 +180,7 @@
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/buttonEnglish"
+                    style="@style/Palace.Button.Outlined.Settings"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -185,42 +189,42 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonFaq"
-                style="@style/Palace.Button.Outlined.Settings"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/account_faq" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonFeedback"
-                style="@style/Palace.Button.Outlined.Settings"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/account_leave_feedback" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/accessibilityStatement"
-                style="@style/Palace.Button.Outlined.Settings"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/account_accessibility_statement" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonPrivacyPolicy"
-                style="@style/Palace.Button.Outlined.Settings"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/accountPrivacyPolicy" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonUserAgreement"
-                style="@style/Palace.Button.Outlined.Settings"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/account_eula" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonLicenses"
-                style="@style/Palace.Button.Outlined.Settings"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/account_licenses" />

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -81,7 +81,7 @@
   <string name="e_kirjasto_logo">E-Kirjasto logo</string>
   <string name="natlibfi_logo">National Library of Finland logo</string>
   <string name="account_application_languages">Application languages:</string>
-  <string name="restartPopupMessage">The application needs to restart to apply the changes. Restart now?</string>
+  <string name="restartPopupMessage">The application needs to restart to apply changes. Restart now?</string>
   <string name="restartPopupTitle">Change app language and restart?</string>
   <string name="restartPopupAgree">Restart</string>
   <string name="restartPopupCancel">Cancel</string>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -80,4 +80,12 @@
   <string name="account_sync_bookmarks_statement">Save your reading position and bookmarks to all your other devices</string>
   <string name="e_kirjasto_logo">E-Kirjasto logo</string>
   <string name="natlibfi_logo">National Library of Finland logo</string>
+  <string name="account_application_languages">Application languages:</string>
+  <string name="restartPopupMessage">The application needs to restart to apply the changes. Restart now?</string>
+  <string name="restartPopupTitle">Change app language and restart?</string>
+  <string name="restartPopupAgree">Restart</string>
+  <string name="restartPopupCancel">Cancel</string>
+  <string name="buttonTextFinnish">Finnish</string>
+  <string name="buttonTextSwedish">Swedish</string>
+  <string name="buttonTextEnglish">English</string>
 </resources>


### PR DESCRIPTION
Add buttons onto the settings page, one for each language. Clicking a button creates a popup telling the user about the app restarting. The app restarts in a couple of seconds, and should work normally even if user restarts manually. The default language is Finnish.

Controlling of language is done by the LocaleHelper, which provides the user chosen language to the application through attachBaseContext on app start. This language is maintained until cache is cleared or language is changed to another through the buttons. TO NOTE: If user changes their system language during running of the application, they will see a mix of the system language and their chosen language until restart, where it goes back to their chosen language.

As Locale gives incorrect information when changing to dark mode (for some reason), we change all language look ups to use LocaleHelper information, that is always correct. This is done for magazines, feed, and link creation. As LocaleHelper requires context, that is added to necessary places. 

This PR also pushes the new version of android-themes, which contains changes to settings page visuals to make the language buttons.

REF EKIR-185