### PR TITLE
Check if secrets are available in CI run

### DIFF
--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Show build info
+        env:
+          TEST_SECRET: ${{ secrets.MASK_TEST }}
         run: scripts/show-ci-info.sh
 
       - name: Set up JDK 17

--- a/.github/workflows/android-pr.yml
+++ b/.github/workflows/android-pr.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Show build info
+        env:
+          TEST_SECRET: ${{ secrets.MASK_TEST }}
         run: scripts/show-ci-info.sh
 
       - name: Set up JDK 17

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Show build info
+        env:
+          TEST_SECRET: ${{ secrets.MASK_TEST }}
         run: scripts/show-ci-info.sh
 
       - name: Set up JDK 17

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,7 @@
 #
 # Build the E-kirjasto Android app.
 #
-# Version 1.1.1
+# Version 1.1.2
 #
 
 trap 'trap - INT; exit $((128 + $(kill -l INT)))' INT
@@ -15,6 +15,8 @@ cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 64
 show_usage() {
   echo "Usage: $(basename "$0") [-h|--help] [BUILD_TYPE]"
   echo
+  # Wrap after 80 characters --> #######################################################
+  echo "Options:"
   echo "-h   --help     Show this help page."
   echo "BUILD_TYPE      Build type to use. Available build types:"
   echo "                - debug (default): debug build"
@@ -23,6 +25,7 @@ show_usage() {
   echo
   echo "This script builds the E-kirjasto app (all flavors)."
   echo "This is mostly used for CI builds, but can be used locally as well."
+  # Wrap after 80 characters --> #######################################################
   echo
 }
 

--- a/scripts/release-checks.sh
+++ b/scripts/release-checks.sh
@@ -3,7 +3,7 @@
 #
 # Run release checks for the E-kirjasto Android app.
 #
-# Version 1.1.2
+# Version 1.1.3
 #
 
 trap 'trap - INT; exit $((128 + $(kill -l INT)))' INT
@@ -100,15 +100,15 @@ fi
 # Get the old version (main branch) and the new version (current commit)
 oldVersion="$(grep '^-' <<< "$versionDiff")"
 oldVersion="${oldVersion#*=}"
-echo "Old version: $oldVersion"
+info "Old version: $oldVersion"
 newVersion="$(grep '^+' <<< "$versionDiff")"
 newVersion="${newVersion#*=}"
-echo "New version: $newVersion"
+info "New version: $newVersion"
 
 oldVersionComparison="$(getVersionComparisonString "$oldVersion")"
 newVersionComparison="$(getVersionComparisonString "$newVersion")"
 if [[ $oldVersionComparison < $newVersionComparison ]]; then
-  echo "The version in the current commit ($newVersion) is newer than the version in the main branch ($oldVersion), all good!"
+  info "The version in the current commit ($newVersion) is newer than the version in the main branch ($oldVersion), all good!"
 else
   fatal "The version in the current commit ($newVersion) must be higher than the version in the main branch ($oldVersion)" 67
 fi

--- a/scripts/release-checks.sh
+++ b/scripts/release-checks.sh
@@ -3,7 +3,7 @@
 #
 # Run release checks for the E-kirjasto Android app.
 #
-# Version 1.1.1
+# Version 1.1.2
 #
 
 trap 'trap - INT; exit $((128 + $(kill -l INT)))' INT
@@ -15,8 +15,11 @@ cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 64
 show_usage() {
   echo "Usage: $(basename "$0") [-h|--help]"
   echo
+  # Wrap after 80 characters --> #######################################################
+  echo "Options:"
   echo "-h   --help                     Show this help page."
   echo "     --skip-transifex-download  Skip downloading new Transifex strings."
+  # Wrap after 80 characters --> #######################################################
   echo
   echo "This script checks if a new E-kirjasto version is ready for release."
   echo "Release checks include:"

--- a/scripts/reveal-secrets.sh
+++ b/scripts/reveal-secrets.sh
@@ -3,7 +3,7 @@
 #
 # Reveal E-kirjasto Android secrets.
 #
-# Version 1.1.1
+# Version 1.1.2
 #
 
 trap 'trap - INT; exit $((128 + $(kill -l INT)))' INT
@@ -63,7 +63,7 @@ done
 base64_to_file() {
   base64Input="$1"
   outputFile="$2"
-  echo "Revealing secret file: $outputFile"
+  info "Revealing secret file: $outputFile"
   echo "$base64Input" | base64 --decode > "$outputFile"
 }
 

--- a/scripts/reveal-secrets.sh
+++ b/scripts/reveal-secrets.sh
@@ -3,7 +3,7 @@
 #
 # Reveal E-kirjasto Android secrets.
 #
-# Version 1.1.0
+# Version 1.1.1
 #
 
 trap 'trap - INT; exit $((128 + $(kill -l INT)))' INT
@@ -15,8 +15,11 @@ cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 64
 show_usage() {
   echo "Usage: $(basename "$0") [-h|--help] [--overwrite]"
   echo
+  # Wrap after 80 characters --> #######################################################
+  echo "Options:"
   echo "-h   --help           Show this help page."
   echo "     --overwrite      Ovewrite existing secret files."
+  # Wrap after 80 characters --> #######################################################
   echo
   echo "This script reveals E-kirjasto build secrets from base64 encoded"
   echo "environment variables."

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3,7 +3,7 @@
 #
 # Run E-kirjasto Android tests.
 #
-# Version 1.0.3
+# Version 1.0.4
 #
 
 trap 'trap - INT; exit $((128 + $(kill -l INT)))' INT
@@ -15,7 +15,10 @@ cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 64
 show_usage() {
   echo "Usage: $(basename "$0") [-h|--help]"
   echo
+  # Wrap after 80 characters --> #######################################################
+  echo "Options:"
   echo "-h   --help           Show this help page."
+  # Wrap after 80 characters --> #######################################################
   echo
   echo "This script runs E-kirjasto unit tests."
   echo

--- a/scripts/show-ci-info.sh
+++ b/scripts/show-ci-info.sh
@@ -3,7 +3,7 @@
 #
 # Show CI info.
 #
-# 1.2.0
+# 1.3.0
 #
 
 trap 'trap - INT; exit $((128 + $(kill -l INT)))' INT
@@ -18,3 +18,10 @@ echo "COMMIT_SHA=$COMMIT_SHA"
 echo "BRANCH_NAME=$BRANCH_NAME"
 echo "TARGET_BRANCH_NAME=$TARGET_BRANCH_NAME"
 echo "----------------------------------------"
+echo
+echo "Checking if secrets are available, fake secret: $TEST_SECRET"
+if [ -z "$TEST_SECRET" ]; then
+    echo "::warning title=Secrets are unavailable::Secrets are not available, this could be a non-member PR (there could be build issues)"
+else
+    echo "Secrets are available!"
+fi

--- a/scripts/show-ci-info.sh
+++ b/scripts/show-ci-info.sh
@@ -3,7 +3,7 @@
 #
 # Show CI info.
 #
-# 1.3.0
+# 1.3.1
 #
 
 trap 'trap - INT; exit $((128 + $(kill -l INT)))' INT
@@ -19,9 +19,9 @@ echo "BRANCH_NAME=$BRANCH_NAME"
 echo "TARGET_BRANCH_NAME=$TARGET_BRANCH_NAME"
 echo "----------------------------------------"
 echo
-echo "Checking if secrets are available, fake secret: $TEST_SECRET"
+info "Checking if secrets are available, fake secret: $TEST_SECRET"
 if [ -z "$TEST_SECRET" ]; then
     echo "::warning title=Secrets are unavailable::Secrets are not available, this could be a non-member PR (there could be build issues)"
 else
-    echo "Secrets are available!"
+    info "Secrets are available!"
 fi

--- a/scripts/transifex.sh
+++ b/scripts/transifex.sh
@@ -3,7 +3,7 @@
 #
 # Transifex Android wrapper.
 #
-# Version 2.1.3
+# Version 2.2.0
 #
 
 basename "$0"
@@ -119,7 +119,7 @@ fi
 
 info "Downloading transifex.jar"
 
-wget -c https://github.com/transifex/transifex-java/releases/download/1.3.0/transifex.jar \
+curl -sLo transifex.jar https://github.com/transifex/transifex-java/releases/download/1.3.0/transifex.jar \
   || fatal "Could not download Transifex" 70
 
 sha256sum -c transifex.sha256 \

--- a/scripts/transifex.sh
+++ b/scripts/transifex.sh
@@ -3,7 +3,7 @@
 #
 # Transifex Android wrapper.
 #
-# Version 2.1.2
+# Version 2.1.3
 #
 
 basename "$0"
@@ -17,11 +17,14 @@ cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.." || exit 64
 show_usage() {
   echo "Usage: $(basename "$0") [-h|--help]"
   echo
+  # Wrap after 80 characters --> #######################################################
+  echo "Options:"
   echo "-h   --help           Show this help page."
   echo "     --append-tags    Append the listed tags to all strings (comma-separated)."
   echo "     --dry-run        Perform a dry-run of an upload."
   echo "     --purge          Purge any deleted source strings."
   echo "     --skip-upload    Skip upload even if the Transifex secret is given."
+  # Wrap after 80 characters --> #######################################################
   echo
   echo "This script uploads and downloads Transifex strings."
   echo

--- a/simplified-app-ekirjasto/src/main/assets/txnative/fi/txstrings.json
+++ b/simplified-app-ekirjasto/src/main/assets/txnative/fi/txstrings.json
@@ -202,7 +202,7 @@
          "string" : "Kirjaudu sisään pääsyavaimella"
       },
       "account_login_suomifi" : {
-         "string" : ""
+         "string" : "Kirjaudu sisään Suomi.fi-tunnistuksella"
       },
       "account_login_with_suomifi" : {
          "string" : "Kirjaudu sisään Suomi.fi-tunnistuksella"
@@ -1018,10 +1018,10 @@
          "string" : "Varaukset"
       },
       "feedWithGroupsEmptyHolds" : {
-         "string" : "Kun varaat kirjan luettelosta, se näkyy täällä. Katso täältä aika ajoin, onko kirjasi ladattavissa."
+         "string" : "Sinulla ei ole voimassa olevia varauksia."
       },
       "feedWithGroupsEmptyLoaned" : {
-         "string" : "Siirry luetteloon ja lisää kirjoja Omat kirjat -kohtaan."
+         "string" : "Sinulla ei ole voimassa olevia lainoja."
       },
       "loginAuthRequired" : {
          "string" : "Todennus vaaditaan. Jatketaan..."
@@ -1090,7 +1090,7 @@
          "string" : "Kirjaudu sisään pääsyavaimella"
       },
       "login_suomifi" : {
-         "string" : ""
+         "string" : "Kirjaudu sisään Suomi.fi-tunnistuksella"
       },
       "login_with_suomifi" : {
          "string" : "Kirjaudu sisään Suomi.fi-tunnistuksella"
@@ -1744,7 +1744,7 @@
          "string" : "Jatka kirjautumatta sisään"
       },
       "tabBooks" : {
-         "string" : "Omat kirjat"
+         "string" : "Omat lainat"
       },
       "tabCatalog" : {
          "string" : "Selaa kirjoja"

--- a/simplified-app-ekirjasto/src/main/assets/txnative/sv/txstrings.json
+++ b/simplified-app-ekirjasto/src/main/assets/txnative/sv/txstrings.json
@@ -202,7 +202,7 @@
          "string" : "Logga in med nyckel"
       },
       "account_login_suomifi" : {
-         "string" : ""
+         "string" : "Logga in med Suomi.fi"
       },
       "account_login_with_suomifi" : {
          "string" : "Logga in med Suomi.fi"
@@ -1090,7 +1090,7 @@
          "string" : "Logga in med nyckel"
       },
       "login_suomifi" : {
-         "string" : ""
+         "string" : "Logga in med Suomi.fi"
       },
       "login_with_suomifi" : {
          "string" : "Logga in med Suomi.fi"


### PR DESCRIPTION
If a non-member (e.g. Dependabot) creates a PR, secrets will not be available in CI builds. This is good for security, but can be confusing, so this PR adds a check for that, and shows a warning+explanation if secrets are not available.

Also changed:
- minor changes to scripts
- updated strings from Transifex