### PR TITLE
Minor CI fixes

### DIFF
--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -49,11 +49,11 @@ jobs:
         run: scripts/build.sh release
 
       - name: Run tests
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: scripts/run-tests.sh
       - name: Upload test report
         uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         with:
           name: junit-test-report
           path: ./simplified-tests/build/reports/tests/testDebugUnitTest/

--- a/.github/workflows/android-pr.yml
+++ b/.github/workflows/android-pr.yml
@@ -46,11 +46,11 @@ jobs:
         run: scripts/build.sh release
 
       - name: Run tests
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: scripts/run-tests.sh
       - name: Upload test report
         uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         with:
           name: junit-test-report
           path: ./simplified-tests/build/reports/tests/testDebugUnitTest/

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -48,11 +48,11 @@ jobs:
         run: scripts/build.sh release
 
       - name: Run tests
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: scripts/run-tests.sh
       - name: Upload test report
         uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         with:
           name: junit-test-report
           path: ./simplified-tests/build/reports/tests/testDebugUnitTest/

--- a/simplified-app-ekirjasto/fastlane/Fastfile
+++ b/simplified-app-ekirjasto/fastlane/Fastfile
@@ -57,7 +57,9 @@ end
 def get_version_name()
   File.open("../../gradle.properties", "r") do |file|
     file.grep(/^ekirjasto\.versionName=/) do |version_line|
-      return version_line.split("=")[1].strip!
+      version = version_line.split("=")[1]
+      version.strip!
+      return version
     end
   end
 end


### PR DESCRIPTION
In CI workflows, use `!cancelled()` instead of `always()`, so that the step only runs if another step failed, not if the whole workflow has been cancelled.

In Ruby (which Fastlane uses), `string.strip!` will return the string only if there was whitespace to strip, so the old code might have sometimes returned `nil`.
