### PR TITLE
Make catalog aware of login state and reload

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
@@ -138,6 +138,21 @@ class CatalogFeedViewModel(
         .subscribe(this::onFeedLoaderResult)
     )
 
+  //Take live data that tells about the state of current account, works as there's only one
+  //account (library) so mostRecent is always the correct account
+  private val accountLiveMutable: MutableLiveData<AccountType> =
+    MutableLiveData(
+      this.profilesController
+        .profileCurrent()
+        .mostRecentAccount()
+    )
+
+  val accountLive: LiveData<AccountType> =
+    this.accountLiveMutable
+
+  val account: AccountType =
+    this.accountLive.value!!
+
   private fun onAccountEvent(event: AccountEvent) {
     when (event) {
       is AccountEventCreation.AccountEventCreationSucceeded,

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
@@ -170,6 +170,10 @@ class CatalogFeedViewModel(
           this.logger.debug("reloading feed due to successful login")
           this.reloadFeed()
         }
+        if ( accountState is AccountLoginState.AccountNotLoggedIn) {
+          this.logger.debug("reloading feed due to log out")
+          this.reloadFeed()
+        }
       }
       CatalogFeedOwnership.CollectedFromAccounts -> {
         if (

--- a/simplified-ui-catalog/src/main/res/values/stringsFeed.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsFeed.xml
@@ -18,8 +18,10 @@
   <string name="feedTitleBooks">Books</string>
   <string name="feedTitleCatalog">Browse Books</string>
   <string name="feedTitleHolds">Holds</string>
-  <string name="feedWithGroupsEmptyHolds">When you reserve a book from the catalog, it will show up here. Look here from time to time to see if your book is available to download.</string>
-  <string name="feedWithGroupsEmptyLoaned">Visit the Catalog to add books to My Books.</string>
+  <string name="feedWithGroupsEmptyHolds">When you reserve a book from the catalog, it will show up here. Look here from time to time to see if your book is available to download.\n Number of reservations is limited to 5.</string>
+  <string name="feedWithGroupsEmptyLoaned">Visit the Catalog to add books to My Books.\n Number of loans is limited to 5.\n Ensure good internet connection when downloading a book and make sure there is enough space on your device.</string>
+  <string name="emptyHoldsNotLoggedIn">Sign in to see your reservations.</string>
+  <string name="emptyLoansNotLoggedIn">Sign in to see your books.</string>
   <string name="ageGateBirthYearPrompt">Please enter your birth year</string>
   <string name="selectYear">Select Year</string>
   <string name="ageVerification">Age Verification</string>


### PR DESCRIPTION
Adds an automatic reload to catalog when user logs out, so that they don't see old information on the loans and reservations pages. Unsure if this helps with the problem of seeing old info when device logs user out on its own. 

Catalog can now observe the login state, and adjusts what info it shows accordingly. Since we have only one account, the most recent account should always be correct one. If user is not logged in it encourages to log in to see their own loans/reservations, and if logged in and feed is empty, it shows important information that the user should know about loaning and reserving.