### PR TITLE
Ekir 260 fix login crashes and error messages

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/passkey/AccountEkirjastoPasskeyFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/passkey/AccountEkirjastoPasskeyFragment.kt
@@ -93,7 +93,14 @@ class AccountEkirjastoPasskeyFragment : Fragment(R.layout.account_ekirjastopassk
         } else {
           postPasskeySuccessful(it.result)
         }
-        is TaskResult.Failure<PasskeyAuth> -> postPasskeyFailed(it)
+        is TaskResult.Failure<PasskeyAuth> ->
+          //If failure was caused by user canceling the passkey login
+          //We only want to cancel the login try without showing error message
+          if (this.viewModel.isCancelled) {
+            listener.post(AccountEkirjastoSuomiFiEvent.Cancel)
+          } else {
+            postPasskeyFailed(it)
+          }
       }
     }
   }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/passkey/AccountEkirjastoPasskeyViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/passkey/AccountEkirjastoPasskeyViewModel.kt
@@ -7,6 +7,7 @@ import androidx.credentials.exceptions.CreateCredentialCustomException
 import androidx.credentials.exceptions.CreateCredentialInterruptedException
 import androidx.credentials.exceptions.CreateCredentialProviderConfigurationException
 import androidx.credentials.exceptions.CreateCredentialUnknownException
+import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.credentials.exceptions.GetCredentialUnsupportedException
 import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException
 import androidx.lifecycle.MutableLiveData
@@ -67,10 +68,13 @@ class AccountEkirjastoPasskeyViewModel (
     services.requireService(BuildConfigurationServiceType::class.java)
   private val steps: TaskRecorderType = TaskRecorder.create()
   private var registering: Boolean = false
+  private var cancelled: Boolean = false
 
   val isRegistering : Boolean
   get() = this.registering
 
+  val isCancelled : Boolean
+    get() = this.cancelled
 
 
   private fun handleFailure(e: Exception) {
@@ -88,6 +92,13 @@ class AccountEkirjastoPasskeyViewModel (
         // to register the credential.
         logger.error("CreateCredentialCancellationException")
         steps.currentStepSucceeded("User cancelled request")
+      }
+      is GetCredentialCancellationException -> {
+        // The user intentionally canceled the operation and chose not
+        // to log in with any credential.
+        this.cancelled = true
+        logger.error("GetCredentialCancellationException")
+        steps.currentStepSucceeded("User cancelled login request")
       }
       is CreateCredentialInterruptedException -> {
         // Retry-able error. Consider retrying the call.

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiFragment.kt
@@ -132,7 +132,8 @@ class AccountEkirjastoSuomiFiFragment : Fragment(R.layout.account_ekirjastosuomi
 
   private fun onSuomiFiEventCancel() {
     logger.debug("User canceled login, pop from the back stack")
-    this.parentFragmentManager.popBackStack()
+    //Tell MainFragmentListenerDelegate to go upwards so that the user is pointed away from the error webpage
+    listener.post(AccountEkirjastoSuomiFiEvent.Cancel)
   }
 
   private fun onSuomiFiEventFailed(event: AccountEkirjastoSuomiFiInternalEvent.Failed) {

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiViewModel.kt
@@ -124,7 +124,6 @@ class AccountEkirjastoSuomiFiViewModel(
       logger.debug("onPageFinished $url")
       url?.let {
         if (it.startsWith(this.description.tunnistus_finish.toString())) {
-          logger.debug(this.description.tunnistus_finish.toString())
           view?.visibility = View.GONE
           view?.evaluateJavascript(
             "(function () { return document.body.textContent; })();"

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiViewModel.kt
@@ -124,6 +124,7 @@ class AccountEkirjastoSuomiFiViewModel(
       logger.debug("onPageFinished $url")
       url?.let {
         if (it.startsWith(this.description.tunnistus_finish.toString())) {
+          logger.debug(this.description.tunnistus_finish.toString())
           view?.visibility = View.GONE
           view?.evaluateJavascript(
             "(function () { return document.body.textContent; })();"
@@ -142,7 +143,7 @@ class AccountEkirjastoSuomiFiViewModel(
     ) {
 
       logger.debug("Parsing authentication data from result")
-      if (content.isBlank() || content == "null") {
+      if (content.isBlank() || content == "null" || content.contains("ERR_HTTP_RESPONSE_CODE_FAILURE")) {
         logger.debug("Empty response, user exited without signing in")
         this.eventSubject.onNext(
           AccountEkirjastoSuomiFiInternalEvent.Cancel()


### PR DESCRIPTION
Fix a login crash that happened at least on emulators, from canceling the Suomi.fi login. 
The canceling of passkey login is handled more gracefully without showing error prompts to the user.
Also made the Suomi.fi login cancel not remain in the error webpage that is shown, 
instead we now close the whole login view by popping the stack in main.

Ref EKIR-260