### PR TITLE
Buttons under cover image and minor text fix

### DIFF
--- a/simplified-ui-catalog/src/main/res/layout/book_detail.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail.xml
@@ -90,14 +90,15 @@
             <LinearLayout
                 android:id="@+id/bookDetailButtons"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/catalogBookDetailButtonsHeight"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
                 android:gravity="start|bottom"
                 android:orientation="horizontal"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/bookDetailCover"
-                app:layout_constraintTop_toBottomOf="@id/bookDetailType">
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/bookDetailCover">
 
                 <!-- These views are removed at runtime and are just present for the sake of the UI editor preview -->
 

--- a/simplified-ui-tutorial/src/main/res/values/strings.xml
+++ b/simplified-ui-tutorial/src/main/res/values/strings.xml
@@ -5,10 +5,10 @@
     <string name="contentDescriptionTutorialPage">Tutorial page</string>
     <string name="contentDescriptionSkipButton">Skip button</string>
     <string name="contentTabDescription">Tutorial</string>
-    <string name="contentDescription1">Welcome to E-library! This service is provided by your local library. Swipe right for next page.</string>
-    <string name="contentDescription2">You can browse e-books and audiobooks by genre, book or author, or browse recommendation lists made by librarians. Swipe right for next page.</string>
-    <string name="contentDescription3">Browse the selection, borrow and read or listen! If a book is on loan, press "reserve" to get it when it becomes available. Swipe right for next page.</string>
-    <string name="contentDescription4">Or do you want something to listen to? The collection also includes an untold number of audiobooks! Click "borrow" to listen to the audiobook. Swipe right to close tutorial.</string>
+    <string name="contentDescription1">Welcome to E-library! This service is provided by your local library. Swipe left for next page.</string>
+    <string name="contentDescription2">You can browse e-books and audiobooks by genre, book or author, or browse recommendation lists made by librarians. Swipe left for next page.</string>
+    <string name="contentDescription3">Browse the selection, borrow and read or listen! If a book is on loan, press "reserve" to get it when it becomes available. Swipe left for next page.</string>
+    <string name="contentDescription4">Or do you want something to listen to? The collection also includes an untold number of audiobooks! Click "borrow" to listen to the audiobook. Swipe left to close tutorial.</string>
     <string name="login_with_suomifi">Sign in with Suomi.fi</string>
     <string name="login_passkey">Sign in with a passkey</string>
     <string name="skip_login">Continue without signing in</string>


### PR DESCRIPTION
This pr moves the buttons on the book detail page under the cover image, so that the buttons are visible and their text better visible all the time. Also corrects the text read by screen readers to be correct.
