### PR TITLE
Ekir 251 add text scaling to settings

### DIFF
--- a/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/FontSizeUtil.kt
+++ b/simplified-ekirjasto-util/src/main/java/fi/kansalliskirjasto/ekirjasto/util/FontSizeUtil.kt
@@ -1,0 +1,30 @@
+package fi.kansalliskirjasto.ekirjasto.util
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class FontSizeUtil (private val sharedPreferences: SharedPreferences) {
+
+  constructor(context: Context) : this(
+    context.getSharedPreferences("APP_PREFERENCES", Context.MODE_PRIVATE)
+  )
+
+  private val KEY_TEXT_SIZE = "text_size"
+
+  /**
+   * Returns the font size currently set in SharedPreferences.
+   * Returns the default if nothing is set.
+   */
+  fun getFontSize(): Float {
+    return sharedPreferences.getFloat(KEY_TEXT_SIZE, 1.0f)
+  }
+
+  /**
+   * Set the given font size to SharedPreferences
+   */
+  fun setFontSize(size: Float) {
+    sharedPreferences.edit().putFloat(KEY_TEXT_SIZE, size).apply()
+
+  }
+
+}

--- a/simplified-main/src/main/java/org/librarysimplified/main/AppCache.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/AppCache.kt
@@ -17,7 +17,6 @@ class AppCache internal constructor(private val sharedPreferences: SharedPrefere
      * SharedPreferences keys
      */
     private const val KEY_SEEN_TUTORIAL = "seen_tutorial"
-    private const val KEY_TEXT_SIZE = "text_size"
 
   }
 
@@ -33,13 +32,5 @@ class AppCache internal constructor(private val sharedPreferences: SharedPrefere
    */
   fun isTutorialSeen(): Boolean {
     return sharedPreferences.getBoolean(KEY_SEEN_TUTORIAL, false)
-  }
-
-  fun setTextSize(size: Float) {
-    sharedPreferences.edit().putFloat(KEY_TEXT_SIZE, size).apply()
-  }
-
-  fun getTextSize(): Float {
-    return sharedPreferences.getFloat(KEY_TEXT_SIZE, 1.0f)
   }
 }

--- a/simplified-main/src/main/java/org/librarysimplified/main/AppCache.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/AppCache.kt
@@ -17,6 +17,8 @@ class AppCache internal constructor(private val sharedPreferences: SharedPrefere
      * SharedPreferences keys
      */
     private const val KEY_SEEN_TUTORIAL = "seen_tutorial"
+    private const val KEY_TEXT_SIZE = "text_size"
+
   }
 
   /**
@@ -31,5 +33,13 @@ class AppCache internal constructor(private val sharedPreferences: SharedPrefere
    */
   fun isTutorialSeen(): Boolean {
     return sharedPreferences.getBoolean(KEY_SEEN_TUTORIAL, false)
+  }
+
+  fun setTextSize(size: Float) {
+    sharedPreferences.edit().putFloat(KEY_TEXT_SIZE, size).apply()
+  }
+
+  fun getTextSize(): Float {
+    return sharedPreferences.getFloat(KEY_TEXT_SIZE, 1.0f)
   }
 }

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
@@ -252,11 +252,9 @@ class MainActivity : AppCompatActivity(R.layout.main_host) {
   override val defaultViewModelProviderFactory: ViewModelProvider.Factory
     get() = this.defaultViewModelFactory
 
-  private var mAppCompatDelegate: AppCompatDelegate? = null //
+  private var mAppCompatDelegate: AppCompatDelegate? = null
   override fun getDelegate(): AppCompatDelegate {
-    logger.debug("GETDELEGATETAPAHTUU ALKU")
     if (mAppCompatDelegate == null) {
-      logger.debug("COMPAT DELEGATE NULL, ASETA TXNATIVE")
       mAppCompatDelegate = TxNative.wrapAppCompatDelegate(super.getDelegate(), this)
     }
 

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
@@ -20,6 +20,9 @@ import androidx.lifecycle.ViewModelProvider
 import com.google.firebase.dynamiclinks.FirebaseDynamicLinks
 import com.google.firebase.dynamiclinks.PendingDynamicLinkData
 import com.transifex.txnative.TxNative
+import com.transifex.txnative.TxResources
+import com.transifex.txnative.activity.TxBaseAppCompatActivity
+import com.transifex.txnative.wrappers.TxContextWrapper
 import fi.kansalliskirjasto.ekirjasto.testing.ui.TestLoginFragment
 import fi.kansalliskirjasto.ekirjasto.util.LocaleHelper
 import org.librarysimplified.services.api.Services
@@ -68,11 +71,22 @@ class MainActivity : AppCompatActivity(R.layout.main_host) {
   }
 
   override fun attachBaseContext(newBase: Context?) {
+    logger.debug("ATTACHBASECONTEXT START")
     fontSizeManager = FontSizeManager(newBase!!)
     val newConfig = Configuration(newBase.resources.configuration)
+    val neBBE = TxResources.getSystem().configuration
     newConfig.fontScale = fontSizeManager.fontSize.scale
-    applyOverrideConfiguration(newConfig)
+    neBBE.fontScale = fontSizeManager.fontSize.scale
+    //val newCont = createConfigurationContext(newConfig)
+    logger.debug(newConfig.toString())
+    logger.debug(TxResources.getSystem().configuration.toString())
+    //applyOverrideConfiguration(neBBE)
+
+    logger.debug("START SUPER:ATTACHB....")
     super.attachBaseContext(LocaleHelper.onAttach(newBase))
+    logger.debug("SET COMPAT DELEGATE TO NULL")
+    //mAppCompatDelegate = null
+    logger.debug("ATTACHBASECONTEXT END")
   }
 
   private fun updateFontSize(fontSize: FontSize) {
@@ -87,6 +101,7 @@ class MainActivity : AppCompatActivity(R.layout.main_host) {
   override fun onCreate(savedInstanceState: Bundle?) {
     this.logger.debug("onCreate (recreating {})", savedInstanceState != null)
     super.onCreate(savedInstanceState)
+    //delegate.setContentView(R.layout.main_host)
     this.logger.debug("onCreate (super completed)")
 
     interceptDeepLink()
@@ -245,9 +260,11 @@ class MainActivity : AppCompatActivity(R.layout.main_host) {
   override val defaultViewModelProviderFactory: ViewModelProvider.Factory
     get() = this.defaultViewModelFactory
 
-  private var mAppCompatDelegate: AppCompatDelegate? = null
+  private var mAppCompatDelegate: AppCompatDelegate? = null //
   override fun getDelegate(): AppCompatDelegate {
+    logger.debug("GETDELEGATETAPAHTUU ALKU")
     if (mAppCompatDelegate == null) {
+      logger.debug("COMPAT DELEGATE NULL, ASETA TXNATIVE")
       mAppCompatDelegate = TxNative.wrapAppCompatDelegate(super.getDelegate(), this)
     }
 
@@ -510,7 +527,7 @@ class FontSizeManager(val context: Context) {
 }
 
 enum class FontSize(val scale: Float) {
-  SMALL(0.7f),
-  DEFAULT(1.0f),
-  LARGE(1.3f)
+  SMALL(1.0f),
+  DEFAULT(1.5f),
+  LARGE(2.0f)
 }

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
@@ -93,7 +93,6 @@ class MainActivity : AppCompatActivity(R.layout.main_host) {
   override fun onCreate(savedInstanceState: Bundle?) {
     this.logger.debug("onCreate (recreating {})", savedInstanceState != null)
     super.onCreate(savedInstanceState)
-    //delegate.setContentView(R.layout.main_host)
     this.logger.debug("onCreate (super completed)")
 
     interceptDeepLink()

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
@@ -153,10 +153,18 @@ class MainActivity : AppCompatActivity(R.layout.main_host) {
         this.logger.debug("TextSmall")
       }
       TextSizeEvent.TextSizeMedium -> {
+        updateFontSize(1.25f)
+        this.logger.debug("TextSmall")
+      }
+      TextSizeEvent.TextSizeLarge -> {
         updateFontSize(1.5f)
         this.logger.debug("TextMedium")
       }
-      TextSizeEvent.TextSizeLarge -> {
+      TextSizeEvent.TextSizeExtraLarge -> {
+        updateFontSize(1.75f)
+        this.logger.debug("TextLarge")
+      }
+      TextSizeEvent.TextSizeExtraExtraLarge -> {
         updateFontSize(2.0f)
         this.logger.debug("TextLarge")
       }

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivityDefaultViewModelFactory.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivityDefaultViewModelFactory.kt
@@ -7,6 +7,7 @@ import org.librarysimplified.ui.splash.SplashEvent
 import org.librarysimplified.ui.tutorial.TutorialEvent
 import org.nypl.simplified.listeners.api.ListenerRepository
 import org.nypl.simplified.listeners.api.ListenerRepositoryFactory
+import org.nypl.simplified.ui.accounts.ekirjasto.TextSizeEvent
 
 class MainActivityDefaultViewModelFactory(fallbackFactory: ViewModelProvider.Factory) :
   ListenerRepositoryFactory<MainActivityListenedEvent, Unit>(fallbackFactory) {
@@ -17,6 +18,7 @@ class MainActivityDefaultViewModelFactory(fallbackFactory: ViewModelProvider.Fac
     repository.registerListener(SplashEvent::class, MainActivityListenedEvent::SplashEvent)
     repository.registerListener(OnboardingEvent::class, MainActivityListenedEvent::OnboardingEvent)
     repository.registerListener(TutorialEvent::class, MainActivityListenedEvent::TutorialEvent)
+    repository.registerListener(TextSizeEvent::class, MainActivityListenedEvent::TextSizeEvent)
     repository.registerListener(MainLoginEvent::class, MainActivityListenedEvent::LoginEvent)
   }
 }

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivityListenedEvent.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivityListenedEvent.kt
@@ -16,6 +16,10 @@ sealed class MainActivityListenedEvent {
     val event: org.librarysimplified.ui.onboarding.OnboardingEvent
   ) : MainActivityListenedEvent()
 
+  data class TextSizeEvent(
+    val event: org.nypl.simplified.ui.accounts.ekirjasto.TextSizeEvent
+  ) : MainActivityListenedEvent()
+
   data class LoginEvent(
     val event: MainLoginEvent
   ) : MainActivityListenedEvent()

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainApplication.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainApplication.kt
@@ -8,6 +8,7 @@ import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
 import androidx.core.content.pm.PackageInfoCompat
+import com.transifex.txnative.TxNative
 import fi.kansalliskirjasto.ekirjasto.testing.TestingOverrides
 import fi.kansalliskirjasto.ekirjasto.util.AppInfoUtil
 import fi.kansalliskirjasto.ekirjasto.util.DataUtil

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainApplication.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainApplication.kt
@@ -8,7 +8,6 @@ import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
 import androidx.core.content.pm.PackageInfoCompat
-import com.transifex.txnative.TxNative
 import fi.kansalliskirjasto.ekirjasto.testing.TestingOverrides
 import fi.kansalliskirjasto.ekirjasto.util.AppInfoUtil
 import fi.kansalliskirjasto.ekirjasto.util.DataUtil

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
@@ -36,6 +36,7 @@ import org.nypl.simplified.ui.accounts.AccountListRegistryEvent
 import org.nypl.simplified.ui.accounts.AccountListRegistryFragment
 import org.nypl.simplified.ui.accounts.AccountPickerEvent
 import org.nypl.simplified.ui.accounts.ekirjasto.EKirjastoAccountFragment
+import org.nypl.simplified.ui.accounts.ekirjasto.PreferencesFragment
 import org.nypl.simplified.ui.accounts.ekirjasto.passkey.AccountEkirjastoPasskeyFragmentParameters
 import org.nypl.simplified.ui.accounts.ekirjasto.suomifi.AccountEkirjastoSuomiFiEvent
 import org.nypl.simplified.ui.accounts.ekirjasto.suomifi.AccountEkirjastoSuomiFiFragment
@@ -399,11 +400,23 @@ internal class MainFragmentListenerDelegate(
         state
       }
 
-      AccountDetailEvent.GoUpwards -> {
+      is AccountDetailEvent.GoUpwards -> {
         this.goUpwards()
         state
       }
+
+      is AccountDetailEvent.OpenPreferences -> {
+        this.openPreferences()
+        state
+      }
     }
+  }
+
+  private fun openPreferences() {
+    this.navigator.addFragment(
+      fragment = PreferencesFragment(),
+      tab = org.librarysimplified.ui.tabs.R.id.tabSettings
+    )
   }
 
   private fun handleAccountSAML20Event(

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailEvent.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailEvent.kt
@@ -20,6 +20,11 @@ sealed class AccountDetailEvent {
 
   object GoUpwards : AccountDetailEvent()
 
+  /**
+   * The patron wants to see the preference options.
+   */
+  object OpenPreferences : AccountDetailEvent()
+
   data class OpenWebView(val parameters: AccountCardCreatorParameters) : AccountDetailEvent()
 
   /**

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -479,19 +479,19 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     alertBuilder.setTitle("Text size")
     alertBuilder.setSingleChoiceItems(languages, current) { dialog, checked ->
       //if the language they choose is not the current one, show the confirmation popup
-      if (checked != current) {
-        when (checked) {
-          0 -> triggerListener.post(
-            TextSizeEvent.TextSizeSmall
-          )
-          1 -> triggerListener.post(
-            TextSizeEvent.TextSizeMedium
-          )
-          2-> triggerListener.post(
-            TextSizeEvent.TextSizeLarge
-          )
-        }
+
+      when (checked) {
+        0 -> triggerListener.post(
+          TextSizeEvent.TextSizeSmall
+        )
+        1 -> triggerListener.post(
+          TextSizeEvent.TextSizeMedium
+        )
+        2-> triggerListener.post(
+          TextSizeEvent.TextSizeLarge
+        )
       }
+
       dialog.dismiss()
     }
     alertBuilder.create().show()

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -78,12 +78,11 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private lateinit var buttonAccessibilityStatement: Button
   private lateinit var buttonLicenses: Button
   private lateinit var buttonFaq: Button
-  private lateinit var buttonLanguage: Button
   private lateinit var versionText: TextView
   private lateinit var bookmarkSyncProgress: ProgressBar
   private lateinit var bookmarkSyncCheck: SwitchCompat
   private lateinit var bookmarkStatement: TextView
-  private lateinit var buttonTextSize: Button
+  private lateinit var buttonPreferences: Button
 
   //inherited elements
   private lateinit var toolbar: PalaceToolbar
@@ -120,10 +119,9 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.buttonUserAgreement = view.findViewById(R.id.buttonUserAgreement)
     this.buttonLicenses = view.findViewById(R.id.buttonLicenses)
     this.buttonFaq = view.findViewById(R.id.buttonFaq)
-    this.buttonLanguage = view.findViewById(R.id.buttonLanguage)
     this.versionText = view.findViewById(R.id.appVersion)
     this.bookmarkSyncCheck = view.findViewById(R.id.accountSyncBookmarksCheck)
-    this.buttonTextSize = view.findViewById(R.id.buttonTextScale)
+    this.buttonPreferences = view.findViewById(R.id.buttonPreferences)
 
 
     this.toolbar =
@@ -161,14 +159,6 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
       this.logger.debug("Register Passkey clicked")
       onTryRegisterPasskey()
     }
-    this.buttonLanguage.setOnClickListener {
-      this.logger.debug("Language button clicked")
-      languageOptions()
-    }
-    this.buttonTextSize.setOnClickListener {
-      this.logger.debug("Text Button clicked")
-      textSizeOptions()
-    }
 
     /*
      * Configure the bookmark syncing switch to enable/disable syncing permissions.
@@ -193,6 +183,15 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
 
     this.reconfigureAccountUI()
   }
+  private fun configurePreferencesButton(button: Button) {
+    button.setOnClickListener {
+      logger.debug("Preferences clicked")
+      this.listener.post(
+        AccountDetailEvent.OpenPreferences
+      )
+    }
+  }
+
 
   private fun configureDocViewButton(button: Button, document: DocumentType?){
     button.isEnabled = document != null
@@ -250,6 +249,8 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     configureDocViewButton(buttonUserAgreement, this.viewModel.documents.eula)
     configureDocViewButton(buttonLicenses, this.viewModel.documents.licenses)
     configureDocViewButton(buttonFaq, this.viewModel.documents.faq)
+
+    configurePreferencesButton(buttonPreferences)
 
     val versionString = this.requireContext().getString(R.string.app_version_string, this.viewModel.appVersion)
     this.versionText.text = versionString
@@ -419,82 +420,6 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.viewModel.account.setLoginState(this.viewModel.account.loginState)
 
     this.subscriptions.clear()
-  }
-  //Show a an alert box with all language options
-  private fun languageOptions() {
-    // Build the dialog, using the translatable language names
-    val alertBuilder = MaterialAlertDialogBuilder(this.requireContext())
-    val languages : Array<String> = arrayOf(
-      getString(R.string.buttonTextFinnish),
-      getString(R.string.buttonTextSwedish),
-      getString(R.string.buttonTextEnglish))
-    val current = LanguageUtil.getUserLanguage(this.requireContext())
-    logger.debug("Current language {}", current)
-    var curr = -1
-    when (current) {
-      "fi" -> curr = 0
-      "sv" -> curr = 1
-      "en" -> curr = 2
-    }
-    alertBuilder.setTitle(R.string.account_application_language)
-    alertBuilder.setSingleChoiceItems(languages, curr) { dialog, checked ->
-      //if the language they choose is not the current one, show the confirmation popup
-      if (checked != curr) {
-        when (checked) {
-          0 -> popUp("fi")
-          1 -> popUp("sv")
-          2-> popUp("en")
-        }
-      }
-      dialog.dismiss()
-    }
-    alertBuilder.create().show()
-  }
-
-  // Show a popup asking if user wants to set chosen language
-  private fun popUp (language: String) {
-    logger.debug("Changing language to {}", language)
-    val builder: AlertDialog.Builder = AlertDialog.Builder(this.requireContext())
-    builder
-      .setMessage(R.string.restartPopupMessage)
-      .setTitle(R.string.restartPopupTitle)
-      .setPositiveButton(R.string.restartPopupAgree) { dialog, which ->
-        //Set locale to the wanted language to be used on restart
-        LocaleHelper.setLocale(this.requireContext(), language)
-      }
-      .setNegativeButton(R.string.restartPopupCancel) { dialog, which ->
-        //do nothing
-      }
-
-    val dialog: AlertDialog = builder.create()
-    dialog.show()
-  }
-
-  private fun textSizeOptions() {
-    // Build the dialog, using the translatable language names
-    val alertBuilder = MaterialAlertDialogBuilder(this.requireContext())
-    val languages : Array<String> = arrayOf("100%", "150%", "200%")
-    val current = 0
-    logger.debug("Current choice {}", current)
-    alertBuilder.setTitle("Text size")
-    alertBuilder.setSingleChoiceItems(languages, current) { dialog, checked ->
-      //if the language they choose is not the current one, show the confirmation popup
-
-      when (checked) {
-        0 -> triggerListener.post(
-          TextSizeEvent.TextSizeSmall
-        )
-        1 -> triggerListener.post(
-          TextSizeEvent.TextSizeMedium
-        )
-        2-> triggerListener.post(
-          TextSizeEvent.TextSizeLarge
-        )
-      }
-
-      dialog.dismiss()
-    }
-    alertBuilder.create().show()
   }
 
   private fun isPasskeySupported(): Boolean {

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -46,6 +46,7 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private val subscriptions: CompositeDisposable =
     CompositeDisposable()
   private val listener: FragmentListenerType<AccountDetailEvent> by fragmentListeners()
+  private val triggerListener: FragmentListenerType<TextSizeEvent> by fragmentListeners()
   private val parameters: AccountFragmentParameters by lazy {
     this.requireArguments()[PARAMETERS_ID] as AccountFragmentParameters
   }
@@ -82,6 +83,7 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private lateinit var bookmarkSyncProgress: ProgressBar
   private lateinit var bookmarkSyncCheck: SwitchCompat
   private lateinit var bookmarkStatement: TextView
+  private lateinit var buttonTextSize: Button
 
   //inherited elements
   private lateinit var toolbar: PalaceToolbar
@@ -121,6 +123,7 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.buttonLanguage = view.findViewById(R.id.buttonLanguage)
     this.versionText = view.findViewById(R.id.appVersion)
     this.bookmarkSyncCheck = view.findViewById(R.id.accountSyncBookmarksCheck)
+    this.buttonTextSize = view.findViewById(R.id.buttonTextScale)
 
 
     this.toolbar =
@@ -161,6 +164,10 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.buttonLanguage.setOnClickListener {
       this.logger.debug("Language button clicked")
       languageOptions()
+    }
+    this.buttonTextSize.setOnClickListener {
+      this.logger.debug("Text Button clicked")
+      textSizeOptions()
     }
 
     /*
@@ -461,6 +468,33 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
 
     val dialog: AlertDialog = builder.create()
     dialog.show()
+  }
+
+  private fun textSizeOptions() {
+    // Build the dialog, using the translatable language names
+    val alertBuilder = MaterialAlertDialogBuilder(this.requireContext())
+    val languages : Array<String> = arrayOf("100%", "150%", "200%")
+    val current = 0
+    logger.debug("Current choice {}", current)
+    alertBuilder.setTitle("Text size")
+    alertBuilder.setSingleChoiceItems(languages, current) { dialog, checked ->
+      //if the language they choose is not the current one, show the confirmation popup
+      if (checked != current) {
+        when (checked) {
+          0 -> triggerListener.post(
+            TextSizeEvent.TextSizeSmall
+          )
+          1 -> triggerListener.post(
+            TextSizeEvent.TextSizeMedium
+          )
+          2-> triggerListener.post(
+            TextSizeEvent.TextSizeLarge
+          )
+        }
+      }
+      dialog.dismiss()
+    }
+    alertBuilder.create().show()
   }
 
   private fun isPasskeySupported(): Boolean {

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
@@ -1,0 +1,147 @@
+package org.nypl.simplified.ui.accounts.ekirjasto
+
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.SwitchCompat
+import androidx.fragment.app.Fragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import fi.kansalliskirjasto.ekirjasto.util.FontSizeUtil
+import fi.kansalliskirjasto.ekirjasto.util.LanguageUtil
+import fi.kansalliskirjasto.ekirjasto.util.LocaleHelper
+import org.librarysimplified.ui.accounts.R
+import org.nypl.simplified.listeners.api.FragmentListenerType
+import org.nypl.simplified.listeners.api.fragmentListeners
+import org.slf4j.LoggerFactory
+
+class PreferencesFragment : Fragment(R.layout.account_resources) {
+  fun create() : PreferencesFragment {
+    val fragment = PreferencesFragment()
+    return fragment
+  }
+
+  private val logger =
+    LoggerFactory.getLogger(PreferencesFragment::class.java)
+  private val listener: FragmentListenerType<TextSizeEvent> by fragmentListeners()
+
+  private lateinit var buttonLanguage: Button
+  private lateinit var buttonFontSize: Button
+  private lateinit var switchPreferences: SwitchCompat
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+
+    this.buttonLanguage = view.findViewById(R.id.buttonLanguage)
+    this.buttonFontSize = view.findViewById(R.id.buttonFontSize)
+    this.switchPreferences = view.findViewById(R.id.accountAllowPreferencesCheck)
+
+    //If settings are different from the default, show the switch as checked
+    if(LocaleHelper.getLanguage(this.requireContext()) != "fi" || FontSizeUtil(this.requireContext()).getFontSize() != 1.0f){
+      switchPreferences.isChecked = true
+    }
+    //Have the buttons start in the same state as the switch
+    this.buttonLanguage.isEnabled = switchPreferences.isChecked
+    this.buttonFontSize.isEnabled = switchPreferences.isChecked
+  }
+
+  override fun onStart() {
+    super.onStart()
+
+    this.buttonLanguage.setOnClickListener {
+      this.logger.debug("Language button clicked")
+      languageOptions()
+    }
+
+    this.buttonFontSize.setOnClickListener {
+      this.logger.debug("Text Button clicked")
+      fontSizeOptions()
+    }
+
+    this.switchPreferences.setOnCheckedChangeListener { buttonView, isChecked ->
+      if (isChecked) {
+        this.buttonFontSize.isEnabled = true
+        this.buttonLanguage.isEnabled = true
+      } else {
+        this.buttonFontSize.isEnabled = false
+        this.buttonLanguage.isEnabled = false
+      }
+    }
+  }
+  //Show a an alert box with all language options
+  private fun languageOptions() {
+    // Build the dialog, using the translatable language names
+    val alertBuilder = MaterialAlertDialogBuilder(this.requireContext())
+    val languages : Array<String> = arrayOf(
+      getString(R.string.buttonTextFinnish),
+      getString(R.string.buttonTextSwedish),
+      getString(R.string.buttonTextEnglish))
+    val current = LanguageUtil.getUserLanguage(this.requireContext())
+    logger.debug("Current language {}", current)
+    var curr = -1
+    when (current) {
+      "fi" -> curr = 0
+      "sv" -> curr = 1
+      "en" -> curr = 2
+    }
+    alertBuilder.setTitle(R.string.account_application_language)
+    alertBuilder.setSingleChoiceItems(languages, curr) { dialog, checked ->
+      //if the language they choose is not the current one, show the confirmation popup
+      if (checked != curr) {
+        when (checked) {
+          0 -> popUp("fi")
+          1 -> popUp("sv")
+          2-> popUp("en")
+        }
+      }
+      dialog.dismiss()
+    }
+    alertBuilder.create().show()
+  }
+
+  // Show a popup asking if user wants to set chosen language
+  private fun popUp (language: String) {
+    logger.debug("Changing language to {}", language)
+    val builder: AlertDialog.Builder = AlertDialog.Builder(this.requireContext())
+    builder
+      .setMessage(R.string.restartPopupMessage)
+      .setTitle(R.string.restartPopupTitle)
+      .setPositiveButton(R.string.restartPopupAgree) { dialog, which ->
+        //Set locale to the wanted language to be used on restart
+        LocaleHelper.setLocale(this.requireContext(), language)
+      }
+      .setNegativeButton(R.string.restartPopupCancel) { dialog, which ->
+        //do nothing
+      }
+
+    val dialog: AlertDialog = builder.create()
+    dialog.show()
+  }
+
+  private fun fontSizeOptions() {
+    // Build the dialog, using the translatable language names
+    val alertBuilder = MaterialAlertDialogBuilder(this.requireContext())
+    val languages : Array<String> = arrayOf("100%", "150%", "200%")
+    val current = 0
+    logger.debug("Current choice {}", current)
+    alertBuilder.setTitle("Text size")
+    alertBuilder.setSingleChoiceItems(languages, current) { dialog, checked ->
+      //if the language they choose is not the current one, show the confirmation popup
+
+      when (checked) {
+        0 -> listener.post(
+          TextSizeEvent.TextSizeSmall
+        )
+        1 -> listener.post(
+          TextSizeEvent.TextSizeMedium
+        )
+        2-> listener.post(
+          TextSizeEvent.TextSizeLarge
+        )
+      }
+
+      dialog.dismiss()
+    }
+    alertBuilder.create().show()
+  }
+}

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
@@ -119,25 +119,35 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
   }
 
   private fun fontSizeOptions() {
-    // Build the dialog, using the translatable language names
+    // Build the dialog
     val alertBuilder = MaterialAlertDialogBuilder(this.requireContext())
     val languages : Array<String> = arrayOf("100%", "150%", "200%")
-    val current = 0
-    logger.debug("Current choice {}", current)
-    alertBuilder.setTitle("Text size")
-    alertBuilder.setSingleChoiceItems(languages, current) { dialog, checked ->
-      //if the language they choose is not the current one, show the confirmation popup
+    //Set the ticked value based on the set font size
+    val current = FontSizeUtil(this.requireContext()).getFontSize()
+    var curr = -1
 
-      when (checked) {
-        0 -> listener.post(
-          TextSizeEvent.TextSizeSmall
-        )
-        1 -> listener.post(
-          TextSizeEvent.TextSizeMedium
-        )
-        2-> listener.post(
-          TextSizeEvent.TextSizeLarge
-        )
+    when (current) {
+      1.0f -> curr = 0
+      1.5f -> curr = 1
+      2.0f -> curr = 2
+    }
+
+    logger.debug("Current choice {}", current)
+    alertBuilder.setTitle(R.string.fontSize)
+    alertBuilder.setSingleChoiceItems(languages, curr) { dialog, checked ->
+      //if the size they choose is not the current one, trigger font change
+      if (checked != curr) {
+        when (checked) {
+          0 -> listener.post(
+            TextSizeEvent.TextSizeSmall
+          )
+          1 -> listener.post(
+            TextSizeEvent.TextSizeMedium
+          )
+          2 -> listener.post(
+            TextSizeEvent.TextSizeLarge
+          )
+        }
       }
 
       dialog.dismiss()

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
@@ -28,21 +28,12 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
   private lateinit var buttonLanguage: Button
   private lateinit var buttonFontSize: Button
   private lateinit var switchPreferences: SwitchCompat
-
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
     this.buttonLanguage = view.findViewById(R.id.buttonLanguage)
     this.buttonFontSize = view.findViewById(R.id.buttonFontSize)
     this.switchPreferences = view.findViewById(R.id.accountAllowPreferencesCheck)
-
-    //If settings are different from the default, show the switch as checked
-    if(LocaleHelper.getLanguage(this.requireContext()) != "fi" || FontSizeUtil(this.requireContext()).getFontSize() != 1.0f){
-      switchPreferences.isChecked = true
-    }
-    //Have the buttons start in the same state as the switch
-    this.buttonLanguage.isEnabled = switchPreferences.isChecked
-    this.buttonFontSize.isEnabled = switchPreferences.isChecked
   }
 
   override fun onStart() {
@@ -67,6 +58,14 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
         this.buttonLanguage.isEnabled = false
       }
     }
+
+    //If settings are different from the default, show the switch as checked
+    if(LocaleHelper.getLanguage(this.requireContext()) != "fi" || FontSizeUtil(this.requireContext()).getFontSize() != 1.0f){
+      switchPreferences.isChecked = true
+    }
+    //Have the buttons start in the same state as the switch
+    this.buttonLanguage.isEnabled = switchPreferences.isChecked
+    this.buttonFontSize.isEnabled = switchPreferences.isChecked
   }
   //Show a an alert box with all language options
   private fun languageOptions() {
@@ -121,15 +120,17 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
   private fun fontSizeOptions() {
     // Build the dialog
     val alertBuilder = MaterialAlertDialogBuilder(this.requireContext())
-    val languages : Array<String> = arrayOf("100%", "150%", "200%")
+    val languages : Array<String> = arrayOf("100%", "125%", "150%", "175%", "200%")
     //Set the ticked value based on the set font size
     val current = FontSizeUtil(this.requireContext()).getFontSize()
     var curr = -1
 
     when (current) {
       1.0f -> curr = 0
-      1.5f -> curr = 1
-      2.0f -> curr = 2
+      1.25f -> curr = 1
+      1.5f -> curr = 2
+      1.75f -> curr = 3
+      2.0f -> curr = 4
     }
 
     logger.debug("Current choice {}", current)
@@ -146,6 +147,12 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
           )
           2 -> listener.post(
             TextSizeEvent.TextSizeLarge
+          )
+          3 -> listener.post(
+            TextSizeEvent.TextSizeExtraLarge
+          )
+          4 -> listener.post(
+            TextSizeEvent.TextSizeExtraExtraLarge
           )
         }
       }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/TextSizeEvent.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/TextSizeEvent.kt
@@ -1,0 +1,10 @@
+package org.nypl.simplified.ui.accounts.ekirjasto
+sealed class TextSizeEvent {
+
+  object TextSizeSmall : TextSizeEvent()
+
+  object TextSizeMedium : TextSizeEvent()
+
+  object TextSizeLarge : TextSizeEvent()
+
+}

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/TextSizeEvent.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/TextSizeEvent.kt
@@ -7,4 +7,8 @@ sealed class TextSizeEvent {
 
   object TextSizeLarge : TextSizeEvent()
 
+  object TextSizeExtraLarge : TextSizeEvent()
+
+  object TextSizeExtraExtraLarge : TextSizeEvent()
+
 }

--- a/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
@@ -153,20 +153,6 @@
             app:layout_constraintTop_toBottomOf="@id/accountTop">
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/buttonLanguage"
-                style="@style/Palace.Button.Outlined.Settings.Arrowed"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/buttonLanguage" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/buttonTextScale"
-                style="@style/Palace.Button.Outlined.Settings.Arrowed"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Text size" />
-
-            <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonFaq"
                 style="@style/Palace.Button.Outlined.Settings.Arrowed"
                 android:layout_width="match_parent"
@@ -207,6 +193,13 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/account_licenses" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonPreferences"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/buttonPreferences" />
 
             <ImageView
                 android:id="@+id/settingsNatLibFiLogo"

--- a/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
@@ -131,6 +131,7 @@
             <TextView
                 android:id="@+id/accountSyncBookmarksStatement"
                 style="@style/Palace.TextViewStyle.Settings"
+                android:textSize="18sp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingBottom="32dp"
@@ -157,6 +158,13 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/buttonLanguage" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonTextScale"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Text size" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonFaq"

--- a/simplified-ui-accounts/src/main/res/layout/account_resources.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_resources.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        android:orientation="vertical">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/accountSyncBookmarks"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:layout_marginTop="32dp"
+            android:background="@color/EkirjastoSettingsBookmarkBackground">
+
+            <TextView
+                android:id="@+id/enableUserPreferencesLabel"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:labelFor="@id/accountAllowPreferencesCheck"
+                android:text="@string/accountAllowPreferences"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/accountAllowPreferencesCheck"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:label="@id/enableUserPreferencesLabel"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonLanguage"
+            style="@style/Palace.Button.Outlined.Settings.Arrowed"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/buttonLanguage" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonFontSize"
+            style="@style/Palace.Button.Outlined.Settings.Arrowed"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/buttonFontSize" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -92,6 +92,7 @@
   <string name="buttonTextFinnish">Finnish</string>
   <string name="buttonTextSwedish">Swedish</string>
   <string name="buttonTextEnglish">English</string>
+  <string name="fontSize">Font size</string>
   <string name="errorLoginFailed">Could not sign in</string>
   <string name="errorPasskeyLoginFailed">Could not sign in with Passkey</string>
   <string name="errorPasskeyRegisterFailed">Error registering a Passkey</string>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -86,6 +86,9 @@
   <string name="restartPopupAgree">Confirm</string>
   <string name="restartPopupCancel">Cancel</string>
   <string name="buttonLanguage">Language options</string>
+  <string name="buttonFontSize">Font size</string>
+  <string name="buttonPreferences">Preferences</string>
+  <string name="accountAllowPreferences">Enable preferences</string>
   <string name="buttonTextFinnish">Finnish</string>
   <string name="buttonTextSwedish">Swedish</string>
   <string name="buttonTextEnglish">English</string>


### PR DESCRIPTION
This pr adds a new fragment called preferences, in which user can find language and font size settings. Language and font functionalities have been moved to the preferences fragment from EkirjastoAccountFragment. Added a new util class that handles font size changes located in SharedPreferences. 

Font size choice is done from a popup, with the options going from 100 to 200%, with 25% increments. Font size is updated without needing to restart the application.

TO NOTE: After updating font size, the back arrow button on the top of the current view does not work anymore!!! 
 Handling of sharedPreferences should be maybe moved to AppCache, as the new file is basically copy of that file.

Ref EKIR-251, EKIR-295