### PR TITLE
UI fixes for scaling

### DIFF
--- a/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
@@ -131,7 +131,6 @@
             <TextView
                 android:id="@+id/accountSyncBookmarksStatement"
                 style="@style/Palace.TextViewStyle.Settings"
-                android:textSize="18sp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingBottom="32dp"

--- a/simplified-ui-catalog/src/main/res/layout/book_detail.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail.xml
@@ -14,7 +14,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
+            android:id="@+id/BookWindow"
             android:focusable="true"
             android:clipChildren="false"
             android:clipToPadding="false">
@@ -87,18 +87,21 @@
                 app:layout_constraintTop_toBottomOf="@id/bookDetailAuthors"
                 tools:text="eBook - The New York Public Library" />
 
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
             <LinearLayout
                 android:id="@+id/bookDetailButtons"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
                 android:gravity="start|bottom"
                 android:orientation="horizontal"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/bookDetailCover">
+                app:layout_constraintTop_toBottomOf="@id/BookWindow">
 
                 <!-- These views are removed at runtime and are just present for the sake of the UI editor preview -->
 
@@ -139,7 +142,6 @@
                     tools:visibility="visible" />
             </LinearLayout>
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <include
             layout="@layout/book_detail_status"


### PR DESCRIPTION
Changed the layout of book_detail so
that the buttons are below the bookcover
and basic informations. This is so that the
text doesn't get hidden under the buttons when scaling.

Also removed the size for the bookmark info as it made the text scale strangely.