### PR TITLE
Ekir 297 fix font change toolbar

### DIFF
--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentDefaultViewModelFactory.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentDefaultViewModelFactory.kt
@@ -11,6 +11,7 @@ import org.nypl.simplified.ui.accounts.AccountDetailEvent
 import org.nypl.simplified.ui.accounts.AccountListEvent
 import org.nypl.simplified.ui.accounts.AccountListRegistryEvent
 import org.nypl.simplified.ui.accounts.AccountPickerEvent
+import org.nypl.simplified.ui.accounts.ekirjasto.PreferencesEvent
 import org.nypl.simplified.ui.accounts.saml20.AccountSAML20Event
 import org.nypl.simplified.ui.accounts.ekirjasto.suomifi.AccountEkirjastoSuomiFiEvent
 import org.nypl.simplified.ui.errorpage.ErrorPageEvent
@@ -33,6 +34,7 @@ class MainFragmentDefaultViewModelFactory(fallbackFactory: ViewModelProvider.Fac
     repository.registerListener(AccountListRegistryEvent::class, MainFragmentListenedEvent::AccountListRegistryEvent)
     repository.registerListener(AccountListEvent::class, MainFragmentListenedEvent::AccountListEvent)
     repository.registerListener(AccountPickerEvent::class, MainFragmentListenedEvent::AccountPickerEvent)
+    repository.registerListener(PreferencesEvent::class, MainFragmentListenedEvent::PreferencesEvent)
     repository.registerListener(MagazinesEvent::class, MainFragmentListenedEvent::MagazinesEvent)
     repository.registerListener(ErrorPageEvent::class, MainFragmentListenedEvent::ErrorPageEvent)
     repository.registerListener(SettingsMainEvent::class, MainFragmentListenedEvent::SettingsMainEvent)

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenedEvent.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenedEvent.kt
@@ -26,6 +26,10 @@ sealed class MainFragmentListenedEvent {
     val event: org.nypl.simplified.ui.accounts.AccountDetailEvent
   ) : MainFragmentListenedEvent()
 
+  data class PreferencesEvent(
+    val event: org.nypl.simplified.ui.accounts.ekirjasto.PreferencesEvent
+  ) : MainFragmentListenedEvent()
+
   data class AccountListEvent(
     val event: org.nypl.simplified.ui.accounts.AccountListEvent
   ) : MainFragmentListenedEvent()

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
@@ -36,6 +36,7 @@ import org.nypl.simplified.ui.accounts.AccountListRegistryEvent
 import org.nypl.simplified.ui.accounts.AccountListRegistryFragment
 import org.nypl.simplified.ui.accounts.AccountPickerEvent
 import org.nypl.simplified.ui.accounts.ekirjasto.EKirjastoAccountFragment
+import org.nypl.simplified.ui.accounts.ekirjasto.PreferencesEvent
 import org.nypl.simplified.ui.accounts.ekirjasto.PreferencesFragment
 import org.nypl.simplified.ui.accounts.ekirjasto.passkey.AccountEkirjastoPasskeyFragmentParameters
 import org.nypl.simplified.ui.accounts.ekirjasto.suomifi.AccountEkirjastoSuomiFiEvent
@@ -169,11 +170,25 @@ internal class MainFragmentListenerDelegate(
       is MainFragmentListenedEvent.AccountPickerEvent ->
         this.handleAccountPickerEvent(event.event, state)
 
+      is MainFragmentListenedEvent.PreferencesEvent ->
+        this.handlePreferencesEvent(event.event, state)
+
       is MainFragmentListenedEvent.MagazinesEvent ->
         this.handleMagazinesEvent(event.event, state)
 
       is MainFragmentListenedEvent.ErrorPageEvent ->
         this.handleErrorPageEvent(event.event, state)
+    }
+  }
+
+  private fun handlePreferencesEvent(
+    event: PreferencesEvent,
+    state: MainFragmentState): MainFragmentState {
+    return when (event) {
+      is PreferencesEvent.GoUpwards -> {
+        this.goUpwardsInSettings()
+        state
+      }
     }
   }
 
@@ -707,6 +722,17 @@ internal class MainFragmentListenerDelegate(
     }
     else {
       openCatalog()
+    }
+  }
+
+  private fun goUpwardsInSettings() {
+    logger.debug("goUpwards(), stack size: {}", navigator.backStackSize())
+    val isRoot = (0 == navigator.backStackSize())
+    if (!isRoot) {
+      navigator.popBackStack()
+    }
+    else {
+      openSettingsAccounts()
     }
   }
 

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -213,7 +213,6 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   }
 
   private fun configureToolbar() {
-    val providerName = this.viewModel.account.provider.displayName
     val actionBar = this.supportActionBar ?: return
     actionBar.show()
     actionBar.setDisplayHomeAsUpEnabled(true)

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -219,7 +219,6 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     actionBar.setDisplayHomeAsUpEnabled(true)
     actionBar.setHomeActionContentDescription(null)
     actionBar.setTitle(R.string.AccountTitle)
-    this.toolbar.logo
     this.toolbar.setLogoOnClickListener {
       this.listener.post(AccountDetailEvent.GoUpwards)
     }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesEvent.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesEvent.kt
@@ -1,0 +1,8 @@
+package org.nypl.simplified.ui.accounts.ekirjasto
+
+sealed class PreferencesEvent {
+
+  //User wants out of preferences into settings
+  object GoUpwards : PreferencesEvent()
+
+}

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
@@ -11,9 +11,12 @@ import fi.kansalliskirjasto.ekirjasto.util.FontSizeUtil
 import fi.kansalliskirjasto.ekirjasto.util.LanguageUtil
 import fi.kansalliskirjasto.ekirjasto.util.LocaleHelper
 import org.librarysimplified.ui.accounts.R
+import org.nypl.simplified.android.ktx.supportActionBar
 import org.nypl.simplified.listeners.api.FragmentListenerType
 import org.nypl.simplified.listeners.api.fragmentListeners
+import org.nypl.simplified.ui.accounts.AccountDetailEvent
 import org.slf4j.LoggerFactory
+import org.thepalaceproject.theme.core.PalaceToolbar
 
 class PreferencesFragment : Fragment(R.layout.account_resources) {
   fun create() : PreferencesFragment {
@@ -24,20 +27,27 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
   private val logger =
     LoggerFactory.getLogger(PreferencesFragment::class.java)
   private val listener: FragmentListenerType<TextSizeEvent> by fragmentListeners()
+  private val navListener: FragmentListenerType<PreferencesEvent> by fragmentListeners()
 
   private lateinit var buttonLanguage: Button
   private lateinit var buttonFontSize: Button
   private lateinit var switchPreferences: SwitchCompat
+
+  private lateinit var toolbar: PalaceToolbar
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
     this.buttonLanguage = view.findViewById(R.id.buttonLanguage)
     this.buttonFontSize = view.findViewById(R.id.buttonFontSize)
     this.switchPreferences = view.findViewById(R.id.accountAllowPreferencesCheck)
+
+    this.toolbar =
+      view.rootView.findViewWithTag(PalaceToolbar.palaceToolbarName)
   }
 
   override fun onStart() {
     super.onStart()
+    this.configureToolbar()
 
     this.buttonLanguage.setOnClickListener {
       this.logger.debug("Language button clicked")
@@ -160,5 +170,16 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
       dialog.dismiss()
     }
     alertBuilder.create().show()
+  }
+  private fun configureToolbar() {
+    val actionBar = this.supportActionBar ?: return
+    actionBar.show()
+    actionBar.setDisplayHomeAsUpEnabled(true)
+    actionBar.setHomeActionContentDescription(null)
+    actionBar.setTitle(R.string.AccountTitle)
+    this.toolbar.setLogoOnClickListener {
+      this.navListener.post(PreferencesEvent.GoUpwards)
+      logger.debug("Backbutton pressed")
+    }
   }
 }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
@@ -186,12 +186,12 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
     actionBar.show()
     //Set the back arrow to take user up a level instead of into the catalog
     actionBar.setDisplayHomeAsUpEnabled(true)
-    //Set no help text description
+    //Set text description to null, text is already provided by the toolbar
     actionBar.setHomeActionContentDescription(null)
     //Set the shown title as Settings
     actionBar.setTitle(R.string.AccountTitle)
     this.toolbar.setLogoOnClickListener {
-      //Pressing the back nutton takes you to last fragment, or if there is not one, settings
+      //Pressing the back button takes you to last fragment, or if there is not one, into settings
       this.navListener.post(PreferencesEvent.GoUpwards)
       logger.debug("Backbutton pressed")
     }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
@@ -37,16 +37,19 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
+    //Link the layout elements
     this.buttonLanguage = view.findViewById(R.id.buttonLanguage)
     this.buttonFontSize = view.findViewById(R.id.buttonFontSize)
     this.switchPreferences = view.findViewById(R.id.accountAllowPreferencesCheck)
 
+    // Inherit the toolbar
     this.toolbar =
       view.rootView.findViewWithTag(PalaceToolbar.palaceToolbarName)
   }
 
   override fun onStart() {
     super.onStart()
+    // Configure toolbar to keep links and texts up-to-date
     this.configureToolbar()
 
     this.buttonLanguage.setOnClickListener {
@@ -59,6 +62,7 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
       fontSizeOptions()
     }
 
+    //Change the availability of the settings buttons based on the switch
     this.switchPreferences.setOnCheckedChangeListener { buttonView, isChecked ->
       if (isChecked) {
         this.buttonFontSize.isEnabled = true
@@ -127,10 +131,11 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
     dialog.show()
   }
 
+  //Show a popup with the text size options from 100 to 200
   private fun fontSizeOptions() {
     // Build the dialog
     val alertBuilder = MaterialAlertDialogBuilder(this.requireContext())
-    val languages : Array<String> = arrayOf("100%", "125%", "150%", "175%", "200%")
+    val fontSizes : Array<String> = arrayOf("100%", "125%", "150%", "175%", "200%")
     //Set the ticked value based on the set font size
     val current = FontSizeUtil(this.requireContext()).getFontSize()
     var curr = -1
@@ -143,9 +148,9 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
       2.0f -> curr = 4
     }
 
-    logger.debug("Current choice {}", current)
+    logger.debug("Current font size choice {}", current)
     alertBuilder.setTitle(R.string.fontSize)
-    alertBuilder.setSingleChoiceItems(languages, curr) { dialog, checked ->
+    alertBuilder.setSingleChoiceItems(fontSizes, curr) { dialog, checked ->
       //if the size they choose is not the current one, trigger font change
       if (checked != curr) {
         when (checked) {
@@ -165,19 +170,28 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
             TextSizeEvent.TextSizeExtraExtraLarge
           )
         }
+      } else {
+        //do nothing
       }
-
       dialog.dismiss()
     }
     alertBuilder.create().show()
   }
+
+  //Configure the toolbar
   private fun configureToolbar() {
+    //Get the action bar from parent
     val actionBar = this.supportActionBar ?: return
+    //Show the bar on the toolbar
     actionBar.show()
+    //Set the back arrow to take user up a level instead of into the catalog
     actionBar.setDisplayHomeAsUpEnabled(true)
+    //Set no help text description
     actionBar.setHomeActionContentDescription(null)
+    //Set the shown title as Settings
     actionBar.setTitle(R.string.AccountTitle)
     this.toolbar.setLogoOnClickListener {
+      //Pressing the back nutton takes you to last fragment, or if there is not one, settings
       this.navListener.post(PreferencesEvent.GoUpwards)
       logger.debug("Backbutton pressed")
     }


### PR DESCRIPTION
The toolbar would not work after changing textsize, and also would adjust incorrectly when moving between preferences fragment and other fragments.

This pr adds a listener for the preferences fragment to the MainFragmentListenerDelegate, that handles the pressing of the back button in the view. The preferences now points back to settings page from the back button, if the stack is empty. Also fixes the fact that after changing font size, the ekirjasto logo disapears from settings page, so made the logo into the ekirjasto logo, if no logo is set.

Refs EKIR-297