### PR TITLE
Ekir 235 add dependents

### DIFF
--- a/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountAuthenticationCredentials.kt
+++ b/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountAuthenticationCredentials.kt
@@ -168,6 +168,7 @@ sealed class AccountAuthenticationCredentials {
   data class Ekirjasto(
     val accessToken: String,
     val ekirjastoToken: String?,
+    val patronPermanentID: String?,
     override val adobeCredentials: AccountAuthenticationAdobePreActivationCredentials?,
     override val authenticationDescription: String?,
     override val annotationsURI: URI?,

--- a/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountProviderAuthenticationDescription.kt
+++ b/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountProviderAuthenticationDescription.kt
@@ -398,7 +398,13 @@ sealed class AccountProviderAuthenticationDescription : Serializable {
     val passkey_login_start: URI,
     val passkey_login_finish: URI,
     val passkey_register_start: URI,
-    val passkey_register_finish: URI
+    val passkey_register_finish: URI,
+
+    /**
+     * URIs for dependent lookup.
+     */
+    val relations: URI,
+    val invite: URI,
 
   ) : AccountProviderAuthenticationDescription() {
     override val isLoginPossible: Boolean =

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountAuthenticationCredentialsJSON.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountAuthenticationCredentialsJSON.kt
@@ -110,6 +110,7 @@ object AccountAuthenticationCredentialsJSON {
         authObject.put("@type", "ekirjasto")
         authObject.put("accessToken", credentials.accessToken)
         authObject.put("ekirjastoToken", credentials.ekirjastoToken)
+        authObject.put("patronPermanentID", credentials.patronPermanentID)
       }
     }
 

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProvidersJSON.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProvidersJSON.kt
@@ -542,8 +542,8 @@ object AccountProvidersJSON {
           passkey_register_finish = JSONParserUtilities.getURI(container, "passkey_register_finish"),
           tunnistus_start = JSONParserUtilities.getURI(container, "tunnistus_start"),
           tunnistus_finish = JSONParserUtilities.getURI(container, "tunnistus_finish"),
-          relations = JSONParserUtilities.getURI(container,"relations"),
-          invite = JSONParserUtilities.getURI(container,"invite")
+          relations = JSONParserUtilities.getURIOrNull(container,"relations")?:URI("null"),
+          invite = JSONParserUtilities.getURIOrNull(container,"invite")?:URI("null")
         )
       }
 

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProvidersJSON.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProvidersJSON.kt
@@ -210,6 +210,8 @@ object AccountProvidersJSON {
         this.putConditionally(authObject, "passkey_register_finish", authentication.passkey_register_finish.toString())
         this.putConditionally(authObject, "tunnistus_start", authentication.tunnistus_start.toString())
         this.putConditionally(authObject, "tunnistus_finish", authentication.tunnistus_finish.toString())
+        this.putConditionally(authObject, "relations", authentication.relations.toString())
+        this.putConditionally(authObject, "invite", authentication.invite.toString())
         authObject
       }
     }
@@ -540,6 +542,8 @@ object AccountProvidersJSON {
           passkey_register_finish = JSONParserUtilities.getURI(container, "passkey_register_finish"),
           tunnistus_start = JSONParserUtilities.getURI(container, "tunnistus_start"),
           tunnistus_finish = JSONParserUtilities.getURI(container, "tunnistus_finish"),
+          relations = JSONParserUtilities.getURI(container,"relations"),
+          invite = JSONParserUtilities.getURI(container,"invite")
         )
       }
 

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/internal/AccountAuthenticationCredentialsJSON20210512.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/internal/AccountAuthenticationCredentialsJSON20210512.kt
@@ -137,6 +137,7 @@ object AccountAuthenticationCredentialsJSON20210512 : AccountAuthenticationCrede
     return AccountAuthenticationCredentials.Ekirjasto(
       accessToken = JSONParserUtilities.getString(obj, "accessToken"),
       ekirjastoToken = JSONParserUtilities.getStringOrNull(obj, "ekirjastoToken")?:"",
+      patronPermanentID = JSONParserUtilities.getString(obj, "patronPermanentID")?:"",
       adobeCredentials = adobeCredentials,
       authenticationDescription = JSONParserUtilities.getStringOrNull(obj, "authenticationDescription"),
       annotationsURI = JSONParserUtilities.getURIOrNull(obj, "annotationsURI"),

--- a/simplified-accounts-source-ekirjasto/src/main/java/org/nypl/simplified/accounts/source/ekirjasto/AccountProviderResolution.kt
+++ b/simplified-accounts-source-ekirjasto/src/main/java/org/nypl/simplified/accounts/source/ekirjasto/AccountProviderResolution.kt
@@ -316,7 +316,10 @@ class AccountProviderResolution(
       authObject.links.find { link -> link.relation == "passkey_register_start" }?.hrefURI
     links["passkey_register_finish"] =
       authObject.links.find { link -> link.relation == "passkey_register_finish" }?.hrefURI
-
+    links["relations"] =
+      authObject.links.find { link -> link.relation == "relations" }?.hrefURI
+    links["invite"] =
+      authObject.links.find { link -> link.relation == "invite" }?.hrefURI
     val emptyLinks = mutableListOf<String>()
     for ((name, link) in links) {
       if (link == null) {
@@ -340,7 +343,9 @@ class AccountProviderResolution(
       passkey_login_start = links["passkey_login_start"]!!,
       passkey_login_finish = links["passkey_login_finish"]!!,
       passkey_register_start = links["passkey_register_start"]!!,
-      passkey_register_finish = links["passkey_register_finish"]!!
+      passkey_register_finish = links["passkey_register_finish"]!!,
+      relations = links["relations"]!!,
+      invite = links["invite"]!!
     )
   }
 

--- a/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderResolution.kt
+++ b/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderResolution.kt
@@ -316,6 +316,10 @@ class AccountProviderResolution(
       authObject.links.find { link -> link.relation == "passkey_register_start" }?.hrefURI
     links["passkey_register_finish"] =
       authObject.links.find { link -> link.relation == "passkey_register_finish" }?.hrefURI
+    links["relations"] =
+      authObject.links.find { link -> link.relation == "relations" }?.hrefURI
+    links["invite"] =
+      authObject.links.find { link -> link.relation == "invite" }?.hrefURI
 
     val emptyLinks = mutableListOf<String>()
     for ((name, link) in links) {
@@ -340,7 +344,9 @@ class AccountProviderResolution(
       passkey_login_start = links["passkey_login_start"]!!,
       passkey_login_finish = links["passkey_login_finish"]!!,
       passkey_register_start = links["passkey_register_start"]!!,
-      passkey_register_finish = links["passkey_register_finish"]!!
+      passkey_register_finish = links["passkey_register_finish"]!!,
+      relations = links["relations"]!!,
+      invite = links["invite"]!!
     )
   }
 

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
@@ -38,6 +38,7 @@ import org.nypl.simplified.ui.accounts.AccountPickerEvent
 import org.nypl.simplified.ui.accounts.ekirjasto.EKirjastoAccountFragment
 import org.nypl.simplified.ui.accounts.ekirjasto.PreferencesEvent
 import org.nypl.simplified.ui.accounts.ekirjasto.PreferencesFragment
+import org.nypl.simplified.ui.accounts.ekirjasto.DependentsFragment
 import org.nypl.simplified.ui.accounts.ekirjasto.passkey.AccountEkirjastoPasskeyFragmentParameters
 import org.nypl.simplified.ui.accounts.ekirjasto.suomifi.AccountEkirjastoSuomiFiEvent
 import org.nypl.simplified.ui.accounts.ekirjasto.suomifi.AccountEkirjastoSuomiFiFragment
@@ -424,6 +425,11 @@ internal class MainFragmentListenerDelegate(
         this.openPreferences()
         state
       }
+
+      is AccountDetailEvent.OpenDependentInvite -> {
+        this.openDependentPage()
+        state
+      }
     }
   }
 
@@ -628,6 +634,12 @@ internal class MainFragmentListenerDelegate(
           comingFromDeepLink = false
         )
       ),
+      tab = org.librarysimplified.ui.tabs.R.id.tabSettings
+    )
+  }
+  private fun openDependentPage() {
+    this.navigator.addFragment(
+      fragment = DependentsFragment(),
       tab = org.librarysimplified.ui.tabs.R.id.tabSettings
     )
   }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailEvent.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailEvent.kt
@@ -70,4 +70,9 @@ sealed class AccountDetailEvent {
     val title: String,
     val url: URL
   ) : AccountDetailEvent()
+
+  /**
+   * Open the dependents view.
+   */
+  object OpenDependentInvite : AccountDetailEvent()
 }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/Dependent.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/Dependent.kt
@@ -1,0 +1,13 @@
+package org.nypl.simplified.ui.accounts.ekirjasto
+
+/**
+ * Data class for dependents.
+ */
+data class Dependent(
+  var locale: String = "fi",
+  val firstName: String,
+  val lastName: String,
+  val govId: String,
+  var email: String = "",
+  val role: String = "customer"
+)

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsFragment.kt
@@ -1,9 +1,12 @@
 package org.nypl.simplified.ui.accounts.ekirjasto
 
+import android.app.Activity
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import android.view.View.GONE
 import android.view.View.VISIBLE
+import android.view.inputmethod.InputMethodManager
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Button
@@ -11,14 +14,12 @@ import android.widget.EditText
 import android.widget.ProgressBar
 import android.widget.Spinner
 import android.widget.TextView
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import fi.kansalliskirjasto.ekirjasto.util.LanguageUtil
-import org.librarysimplified.services.api.Services
 import org.librarysimplified.ui.accounts.R
-import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.slf4j.LoggerFactory
+
 
 class DependentsFragment : Fragment(R.layout.dependents) {
   //Viewmodel that handles get/post requests as well as updating dependent list
@@ -204,6 +205,8 @@ class DependentsFragment : Fragment(R.layout.dependents) {
         buttonDependents.visibility = GONE
         progressBar.visibility = VISIBLE
         dependentInfoText.visibility = GONE
+        //Hide the keyboard if still open
+        this.hideKeyboardFrom(this.requireContext(),this.requireView())
 
         //Post the dependent info
         postDependent(selectedDependent,userInput)
@@ -224,6 +227,14 @@ class DependentsFragment : Fragment(R.layout.dependents) {
   private fun isEmailValid(userInput: String): Boolean {
     val emailRegex = "^[A-Za-z](.*)(@)(.+)(\\.)(.+)"
     return userInput.matches(emailRegex.toRegex())
+  }
+
+  /**
+   * Hide keyboard from the user.
+   */
+  fun hideKeyboardFrom(context: Context, view: View) {
+    val imm = context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+    imm.hideSoftInputFromWindow(view.windowToken, 0)
   }
 
   /**

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsFragment.kt
@@ -96,30 +96,34 @@ class DependentsFragment : Fragment(R.layout.dependents) {
       //If there was an error or success, should hide spinner and loading
       spinner.visibility = GONE
       progressBar.visibility = GONE
-      if (error == "Success") {
-        //Set thank you message and show it
-        dependentInfoText.text = getString(R.string.thanks)
-        dependentInfoText.visibility = VISIBLE
-        //Show the invite another -button
-        moreDependentsButton.visibility = VISIBLE
-      } else if (error == "Error"){
-        //Error is from the server
-        //Set and show error message
-        dependentInfoText.text = getString(R.string.errorFromServer)
-        dependentInfoText.visibility = VISIBLE
-        //Show the get dependents button so user can try again
-        buttonDependents.visibility = VISIBLE
-        //Don't show invite more in case of a fail
-        moreDependentsButton.visibility = GONE
-      } else {
-        //Error happened on this end
-        //Set and show error message
-        dependentInfoText.text = getString(R.string.errorInCreation)
-        dependentInfoText.visibility = VISIBLE
-        //Show the get dependents button so user can try again
-        buttonDependents.visibility = VISIBLE
-        //Don't show invite more in case of a fail
-        moreDependentsButton.visibility = GONE
+      when (error) {
+          "Success" -> {
+            //Set thank you message and show it
+            dependentInfoText.text = getString(R.string.thanks)
+            dependentInfoText.visibility = VISIBLE
+            //Show the invite another -button
+            moreDependentsButton.visibility = VISIBLE
+          }
+          "Error" -> {
+            //Error is from the server
+            //Set and show error message
+            dependentInfoText.text = getString(R.string.errorFromServer)
+            dependentInfoText.visibility = VISIBLE
+            //Show the get dependents button so user can try again
+            buttonDependents.visibility = VISIBLE
+            //Don't show invite more in case of a fail
+            moreDependentsButton.visibility = GONE
+          }
+          else -> {
+            //Error happened on this end
+            //Set and show error message
+            dependentInfoText.text = getString(R.string.errorInCreation)
+            dependentInfoText.visibility = VISIBLE
+            //Show the get dependents button so user can try again
+            buttonDependents.visibility = VISIBLE
+            //Don't show invite more in case of a fail
+            moreDependentsButton.visibility = GONE
+          }
       }
     }
 

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsFragment.kt
@@ -157,9 +157,9 @@ class DependentsFragment : Fragment(R.layout.dependents) {
         }
       }
 
-      //handle nothing selected
+      //handle nothing in spinner selected
       override fun onNothingSelected(parent: AdapterView<*>?) {
-        //no item selected, therefore user cannot continue
+        //no item selected from the spinner, therefore user cannot continue
         //so we are hiding everything
         emailInput.visibility = GONE
         send.visibility = GONE
@@ -216,13 +216,21 @@ class DependentsFragment : Fragment(R.layout.dependents) {
     }
   }
 
-  //validate user input email
+
+  /**
+   * Validate user input email.
+   * Returns true if valid, otherwise false.
+   */
   private fun isEmailValid(userInput: String): Boolean {
     val emailRegex = "^[A-Za-z](.*)(@)(.+)(\\.)(.+)"
     return userInput.matches(emailRegex.toRegex())
   }
 
-  //Trigger the post method
+  /**
+   * Trigger post method for a dependent.
+   * Provides dependent name, email and language to ViewModel.
+   */
+
   private fun postDependent(dependentName: String, email: String) {
     logger.debug("Entered post method")
     //Get the users language and use it as the dependents language

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsFragment.kt
@@ -102,9 +102,19 @@ class DependentsFragment : Fragment(R.layout.dependents) {
         dependentInfoText.visibility = VISIBLE
         //Show the invite another -button
         moreDependentsButton.visibility = VISIBLE
-      } else {
+      } else if (error == "Error"){
+        //Error is from the server
         //Set and show error message
-        dependentInfoText.text = error
+        dependentInfoText.text = getString(R.string.errorFromServer)
+        dependentInfoText.visibility = VISIBLE
+        //Show the get dependents button so user can try again
+        buttonDependents.visibility = VISIBLE
+        //Don't show invite more in case of a fail
+        moreDependentsButton.visibility = GONE
+      } else {
+        //Error happened on this end
+        //Set and show error message
+        dependentInfoText.text = getString(R.string.errorInCreation)
         dependentInfoText.visibility = VISIBLE
         //Show the get dependents button so user can try again
         buttonDependents.visibility = VISIBLE

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsFragment.kt
@@ -232,7 +232,7 @@ class DependentsFragment : Fragment(R.layout.dependents) {
   /**
    * Hide keyboard from the user.
    */
-  fun hideKeyboardFrom(context: Context, view: View) {
+  private fun hideKeyboardFrom(context: Context, view: View) {
     val imm = context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
     imm.hideSoftInputFromWindow(view.windowToken, 0)
   }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsFragment.kt
@@ -1,0 +1,219 @@
+package org.nypl.simplified.ui.accounts.ekirjasto
+
+import android.os.Bundle
+import android.view.View
+import android.view.View.GONE
+import android.view.View.VISIBLE
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Button
+import android.widget.EditText
+import android.widget.ProgressBar
+import android.widget.Spinner
+import android.widget.TextView
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import fi.kansalliskirjasto.ekirjasto.util.LanguageUtil
+import org.librarysimplified.services.api.Services
+import org.librarysimplified.ui.accounts.R
+import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
+import org.slf4j.LoggerFactory
+
+class DependentsFragment : Fragment(R.layout.dependents) {
+  //Viewmodel that handles get/post requests as well as updating dependent list
+  private lateinit var viewModel: DependentsViewModel
+  val logger = LoggerFactory.getLogger(DependentsFragment::class.java)
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    //Create the viewmodel
+    this.viewModel = ViewModelProvider(this)[DependentsViewModel::class.java]
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    //Link all the view elements to their counterparts
+    val spinner = view.findViewById<Spinner>(R.id.spinner)
+    val emailInput = view.findViewById<EditText>(R.id.email)
+    val send = view.findViewById<Button>(R.id.send)
+    val buttonDependents = view.findViewById<Button>(R.id.buttonDependents)
+    val dependentInfoText = view.findViewById<TextView>(R.id.dependentInfoText)
+    val progressBar = view.findViewById<ProgressBar>(R.id.dependentsLoading)
+    val moreDependentsButton = view.findViewById<Button>(R.id.invMoreDependents)
+
+    //set elements to be invisible at start
+    emailInput.visibility = GONE
+    send.visibility = GONE
+    dependentInfoText.visibility = GONE
+    spinner.visibility = GONE
+    progressBar.visibility = GONE
+    moreDependentsButton.visibility = GONE
+
+    //Handle click event of a get dependents button
+    buttonDependents.setOnClickListener {
+      logger.debug("Get Dependents Button Pressed!")
+      //Call the viewmodel to handle getting the dependents from the server
+      viewModel.lookupDependents()
+      //Show progress bar while we are loading the dependents info
+      buttonDependents.visibility = GONE
+      progressBar.visibility = VISIBLE
+    }
+
+    //Add an adapter for programmatically adding spinner items when there are some
+    val adapter = ArrayAdapter<String>(requireContext(), android.R.layout.simple_spinner_item)
+    adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+    spinner.adapter = adapter
+
+    //Observe the list of dependents and put them into the spinner and show the spinner when done
+    //also stop showing the progress bar when there is something to show
+    viewModel.dependentListLive.observe(viewLifecycleOwner) { dependents ->
+      if (dependents.isNotEmpty()) {
+        adapter.clear()
+        adapter.add(getString(R.string.select_dependent))
+        //adapter.add("Another Item for debugging purposes only")
+        dependents.forEach { dependent ->
+          adapter.add(dependent.firstName)
+        }
+        adapter.notifyDataSetChanged()
+        //Show results
+        spinner.visibility = VISIBLE
+      } else {
+        //User has no dependents so inform user
+        dependentInfoText.text = getString(R.string.no_dependents)
+        dependentInfoText.visibility = VISIBLE
+        //Don't show spinner if no dependents
+        spinner.visibility = GONE
+      }
+      //After loading we want to hide progress bar
+      progressBar.visibility = GONE
+      //After loading we want to show the dependents lookup button again
+      buttonDependents.visibility = VISIBLE
+    }
+
+    //Observe possible error states that the user should be informed of
+    viewModel.errorLive.observe(viewLifecycleOwner) { error ->
+      //If there was an error or success, should hide spinner and loading
+      spinner.visibility = GONE
+      progressBar.visibility = GONE
+      if (error == "Success") {
+        //Set thank you message and show it
+        dependentInfoText.text = getString(R.string.thanks)
+        dependentInfoText.visibility = VISIBLE
+        //Show the invite another -button
+        moreDependentsButton.visibility = VISIBLE
+      } else {
+        //Set and show error message
+        dependentInfoText.text = error
+        dependentInfoText.visibility = VISIBLE
+        //Show the get dependents button so user can try again
+        buttonDependents.visibility = VISIBLE
+        //Don't show invite more in case of a fail
+        moreDependentsButton.visibility = GONE
+      }
+    }
+
+    //set state of selection boolean to false and send to debug console
+    var selected = false
+    var selectedDependent = ""
+    logger.debug("State of selection is $selected")
+
+    //Set up item selection listener
+    spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+      override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+        val selectedItem = parent?.getItemAtPosition(position).toString()
+
+        // Handle the selected item here and post selection to debug console
+        logger.debug("Item Selected: $selectedItem")
+
+        //Check if selected other than default value
+        //and if so, set input field, info and send button visible
+        if (selectedItem == getString(R.string.select_dependent)) {
+          emailInput.visibility = GONE
+          send.visibility = GONE
+          dependentInfoText.visibility = GONE
+          selected = false
+        } else {
+          selected = true
+          logger.debug("State of selection is $selected")
+          selectedDependent = selectedItem
+          emailInput.visibility = VISIBLE
+          send.visibility = VISIBLE
+          dependentInfoText.visibility = VISIBLE
+        }
+      }
+
+      //handle nothing selected
+      override fun onNothingSelected(parent: AdapterView<*>?) {
+        //no item selected, therefore user cannot continue
+        //so we are hiding everything
+        emailInput.visibility = GONE
+        send.visibility = GONE
+        dependentInfoText.visibility = GONE
+      }
+    }
+
+    moreDependentsButton.setOnClickListener {
+      //Return the user to the spinner view
+
+      //Hide this button
+      moreDependentsButton.visibility = GONE
+
+      //Show spinner, resetting it to first value
+      spinner.setSelection(0)
+      spinner.visibility = VISIBLE
+
+      //Reset email field
+      emailInput.text.clear()
+
+      //Reset the info text
+      dependentInfoText.visibility = GONE
+      dependentInfoText.text = getString(R.string.guidetext)
+
+      //Show get dependents button
+      buttonDependents.visibility = VISIBLE
+    }
+
+    // handle click event of a send button
+    send.setOnClickListener {
+      logger.debug("Send Button Pressed!")
+
+      //Getting the value user has put on the email text field and send it to debug
+      val userInput: String = emailInput.text.toString()
+
+      //validating user email, if valid, we post it
+      if (isEmailValid(userInput)) {
+        //hide everything except progress bar
+        send.visibility = GONE
+        emailInput.visibility = GONE
+        spinner.visibility = GONE
+        buttonDependents.visibility = GONE
+        progressBar.visibility = VISIBLE
+        dependentInfoText.visibility = GONE
+
+        //Post the dependent info
+        postDependent(selectedDependent,userInput)
+
+
+      } else {
+        //If email is not email, inform user to try with a valid one
+        dependentInfoText.text = getString(R.string.emailNotValid)
+      }
+    }
+  }
+
+  //validate user input email
+  private fun isEmailValid(userInput: String): Boolean {
+    val emailRegex = "^[A-Za-z](.*)(@)(.+)(\\.)(.+)"
+    return userInput.matches(emailRegex.toRegex())
+  }
+
+  //Trigger the post method
+  private fun postDependent(dependentName: String, email: String) {
+    logger.debug("Entered post method")
+    //Get the users language and use it as the dependents language
+    val lang = LanguageUtil.getUserLanguage(this.requireContext())
+    viewModel.postDependent(dependentName, email, lang)
+  }
+
+}

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsViewModel.kt
@@ -112,14 +112,14 @@ class DependentsViewModel(
             logger.warn("fetchEkirjastoToken error: {}", response)
             logger.warn("Error ${response.status}: ${response.properties?.message}")
             steps.currentStepFailed("Error getting ekirjastoToken", response.properties!!.message)
-            error.postValue("Something went wrong. Try again.")
+            error.postValue("Error")
           }
           is LSHTTPResponseStatus.Failed -> {
             //Handle error by logging and informing user
             logger.warn("fetchEkirjastoToken failed: {}", response)
             logger.warn("Failed ${response.status}: ${response.properties?.message}")
             steps.currentStepFailed("Failed to get ekirjastoToken", response.properties!!.message)
-            error.postValue("Could not finish request, check internet connection and try again.")
+            error.postValue("Failed")
           }
         }
       }
@@ -169,14 +169,14 @@ class DependentsViewModel(
             //Handle error by logging and informing user
             logger.warn("fetchDependents error: {}", response)
             logger.warn("Error ${response.status}: ${response.properties?.message}")
-            error.postValue("Something went wrong. Sign out and back in and try again.")
+            error.postValue("Error")
 
           }
           is LSHTTPResponseStatus.Failed -> {
             //Handle error by logging and informing user
             logger.warn("fetchDependents failed: {}", response)
             logger.warn("Failed ${response.status}: ${response.properties?.message}")
-            error.postValue("Could not finish request. Check internet connection and try again.")
+            error.postValue("Failed")
           }
         }
       }
@@ -225,13 +225,13 @@ class DependentsViewModel(
                 //Handle error by logging and informing user
                 logger.warn("postDependent error: {}", response)
                 logger.warn("Error ${response.status}: ${response.properties?.message}")
-                error.postValue("There was an error, try again.")
+                error.postValue("Error")
               }
               is LSHTTPResponseStatus.Failed -> {
                 //Handle error by logging and informing user
                 logger.warn("postDependent failed: {}", response)
                 logger.warn("Failed ${response.status}: ${response.properties?.message}")
-                error.postValue("Failed to send data to server. Sign out and back in and try again.")
+                error.postValue("Failed")
               }
             }
           }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsViewModel.kt
@@ -1,0 +1,268 @@
+package org.nypl.simplified.ui.accounts.ekirjasto
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import one.irradia.mime.api.MIMEType
+import org.librarysimplified.http.api.LSHTTPAuthorizationBearerToken
+import org.librarysimplified.http.api.LSHTTPClientType
+import org.librarysimplified.http.api.LSHTTPRequestBuilderType
+import org.librarysimplified.http.api.LSHTTPRequestType
+import org.librarysimplified.http.api.LSHTTPResponseStatus
+import org.librarysimplified.services.api.Services
+import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
+import org.nypl.simplified.accounts.api.AccountProviderAuthenticationDescription
+import org.nypl.simplified.accounts.database.api.AccountType
+import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
+import org.nypl.simplified.taskrecorder.api.TaskRecorder
+import org.nypl.simplified.taskrecorder.api.TaskRecorderType
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.nio.charset.Charset
+
+class DependentsViewModel(
+) : ViewModel() {
+
+  private val services = Services.serviceDirectory()
+  private val profiles = services.requireService(ProfilesControllerType::class.java)
+  private val http = services.requireService(LSHTTPClientType::class.java)
+  private val logger = LoggerFactory.getLogger(DependentsViewModel::class.java)
+  private val steps: TaskRecorderType = TaskRecorder.create()
+
+  //List of the dependents returned by the server
+  private val dependentList = MutableLiveData<List<Dependent>>()
+
+  //Observable dependent list
+  val dependentListLive: LiveData<List<Dependent>>
+    get() = dependentList
+
+  //ekirjasto token returned by circulation
+  private lateinit var ekirjastoToken : String
+  //dependent post URI
+  private lateinit var dependentPostURI: URI
+
+  //Error message
+  private val error =  MutableLiveData<String>()
+
+  //Observable error message
+  val errorLive: LiveData<String>
+    get() = error
+
+  //Get the used account (we only have one)
+  private fun getDefaultAccount(): AccountType? {
+    steps.beginNewStep("Get current account")
+    val profile = profiles.profileCurrent()
+    val mostRecentId = profile.preferences().mostRecentAccount
+
+    try {
+      steps.currentStepSucceeded("Found account")
+      return profile.account(mostRecentId)
+    } catch (e: Exception) {
+      logger.error("stale account: ", e)
+    }
+    return null
+  }
+
+  fun lookupDependents() {
+    //Get account information
+    //Get id of default account, that we are always on
+    val accountId = getDefaultAccount()!!.id
+    //We only have one profile, ekirjasto
+    val profile = profiles.profileCurrent()
+    //Get the matching account from ekirjasto
+    val account = profile.account(accountId)
+    //Credentials are of the type Ekirjasto always
+    val credentials = account.loginState.credentials as? AccountAuthenticationCredentials.Ekirjasto
+    //AuthDescription contains URIs used
+    val ekirjastoAuthDescription =
+      account.provider.authentication as? AccountProviderAuthenticationDescription.Ekirjasto
+    steps.beginNewStep("Get token and patron info from profile")
+    val circulationToken = credentials?.accessToken
+    val patron = credentials?.patronPermanentID
+    steps.currentStepSucceeded("Token and patron found in profile")
+    steps.beginNewStep("Get the dependent and token URIs from description")
+    val ekirjastoTokenUrl = ekirjastoAuthDescription?.ekirjasto_token
+    val dependentURI = URI(ekirjastoAuthDescription?.relations.toString().replace("patron", patron!!))
+    this.dependentPostURI = ekirjastoAuthDescription?.invite!!
+    steps.currentStepSucceeded("URIs found in description")
+
+    //Get the ekirjastoToken from circulation
+    steps.beginNewStep("Get Ekirjasto token")
+    this.viewModelScope.launch(Dispatchers.IO) {
+      // Create the request for ekirjasto token
+      val tokenRequest = createGetTokenRequest(ekirjastoTokenUrl!!, circulationToken!!)
+      tokenRequest.execute().use { response ->
+        when (val status = response.status) {
+          is LSHTTPResponseStatus.Responded.OK -> {
+            //return gives us a token that is to be used in loikka calls
+            val mapper = ObjectMapper()
+            val jsonNode = mapper.readTree(status.bodyStream)
+            //extract the token from answer
+            ekirjastoToken = jsonNode.get("token").asText()
+            steps.currentStepSucceeded("Got Ekirjasto token")
+          }
+          is LSHTTPResponseStatus.Responded.Error -> {
+            //Handle error by logging and informing user
+            logger.warn("fetchEkirjastoToken error: {}", response)
+            logger.warn("Error ${response.status}: ${response.properties?.message}")
+            steps.currentStepFailed("Error getting ekirjastoToken", response.properties!!.message)
+            error.postValue("Something went wrong. Try again.")
+          }
+          is LSHTTPResponseStatus.Failed -> {
+            //Handle error by logging and informing user
+            logger.warn("fetchEkirjastoToken failed: {}", response)
+            logger.warn("Failed ${response.status}: ${response.properties?.message}")
+            steps.currentStepFailed("Failed to get ekirjastoToken", response.properties!!.message)
+            error.postValue("Could not finish request, check internet connection and try again.")
+          }
+        }
+      }
+      //Get the dependents
+      steps.beginNewStep("Start dependents lookup")
+      //Get dependents request
+      val dependentsRequest = createDependentsRequest(dependentURI, ekirjastoToken)
+      dependentsRequest.execute().use { response ->
+        when (val status = response.status) {
+          is LSHTTPResponseStatus.Responded.OK -> {
+            //currently call returns list of items, that are the dependents
+            //the list is called items (for some reason)
+
+            //Get a mapper for mapping the dependent values
+            val mapper = ObjectMapper()
+            //Read into json node the server answer
+            val jsonNode = mapper.readTree(status.bodyStream)
+            //create an array node from the values listed as items
+            val arrayNode = jsonNode["items"] as ArrayNode
+            //get an iterator of the elements aka. dependents
+            val itr = arrayNode.elements()
+            steps.currentStepSucceeded("Dependents looked up and listed")
+
+            //list of dependents that are returned to fragment
+            val depends = mutableListOf<Dependent>()
+            //iterate through the dependents as long as there are values
+            while (itr.hasNext()) {
+              logger.debug("Has a child")
+              val dep = itr.next()
+              //Convert into a dependent
+              val user = Dependent(
+                firstName = dep["firstName"].asText(),
+                lastName = dep["lastName"].asText(),
+                govId = dep["govId"].asText()
+              )
+              // add user to list
+              depends.add(user)
+            }
+            steps.beginNewStep("Update dependents list started")
+            //Post the dependent to the server
+            dependentList.postValue(depends)
+            steps.currentStepSucceeded("Dependents list updated")
+            return@launch
+          }
+
+          is LSHTTPResponseStatus.Responded.Error -> {
+            //Handle error by logging and informing user
+            logger.warn("fetchDependents error: {}", response)
+            logger.warn("Error ${response.status}: ${response.properties?.message}")
+            error.postValue("Something went wrong. Sign out and back in and try again.")
+
+          }
+          is LSHTTPResponseStatus.Failed -> {
+            //Handle error by logging and informing user
+            logger.warn("fetchDependents failed: {}", response)
+            logger.warn("Failed ${response.status}: ${response.properties?.message}")
+            error.postValue("Could not finish request. Check internet connection and try again.")
+          }
+        }
+      }
+    }
+  }
+
+  private fun createGetTokenRequest(ekirjastoTokenUri: URI, accessToken: String): LSHTTPRequestType {
+    //Create the ekirjasto token request
+    return this.http.newRequest(ekirjastoTokenUri)
+      .setAuthorization(
+        LSHTTPAuthorizationBearerToken.ofToken(accessToken)
+      )
+      .build()
+  }
+
+  private fun createDependentsRequest(dependentURI: URI, token: String) : LSHTTPRequestType{
+    //Request from loikka the dependents, set the token we just got as the bearertoken
+    return this.http.newRequest(dependentURI)
+      .setAuthorization(
+        LSHTTPAuthorizationBearerToken.ofToken(token)
+      )
+      .build()
+  }
+
+  fun postDependent(dependentName: String, email: String, lang : String) {
+      //Get correct dependent
+      val correctDependent = dependentList.value?.find { it.firstName == dependentName }
+
+      if (correctDependent != null) {
+        //Add email and parent's language to the dependent
+        correctDependent.email = email
+        correctDependent.locale = lang
+
+        //Post the dependent
+        this.viewModelScope.launch(Dispatchers.IO) {
+          val dependentPostRequest = createDependentPost(correctDependent)
+          dependentPostRequest.execute().use { response ->
+            when (val status = response.status) {
+              is LSHTTPResponseStatus.Responded.OK -> {
+                //Inform user that the post went through correctly
+                logger.debug("Server responded OK")
+                error.postValue("Success")
+                return@launch
+              }
+              is LSHTTPResponseStatus.Responded.Error -> {
+                //Handle error by logging and informing user
+                logger.warn("postDependent error: {}", response)
+                logger.warn("Error ${response.status}: ${response.properties?.message}")
+                error.postValue("There was an error, try again.")
+              }
+              is LSHTTPResponseStatus.Failed -> {
+                //Handle error by logging and informing user
+                logger.warn("postDependent failed: {}", response)
+                logger.warn("Failed ${response.status}: ${response.properties?.message}")
+                error.postValue("Failed to send data to server. Sign out and back in and try again.")
+              }
+            }
+          }
+        }
+      }  else {
+        logger.debug("No dependent with that name")
+      }
+    }
+
+
+  private fun createDependentPost(dependent: Dependent) : LSHTTPRequestType{
+    //Get mapper
+    val mapper = ObjectMapper()
+    //Read dependent into object node
+    val body = mapper.valueToTree<ObjectNode>(dependent)
+    //Change the object to string
+    val bodyString = mapper.writeValueAsString(body)
+
+    this.logger.debug("Post Dependent Request: {}", bodyString)
+
+    //Put the dependent into the request as the body, use ekirjastoToken as bearer
+    return this.http.newRequest(this.dependentPostURI)
+      .setAuthorization(
+        LSHTTPAuthorizationBearerToken.ofToken(ekirjastoToken)
+      )
+      .setMethod(
+        LSHTTPRequestBuilderType.Method.Post(
+          bodyString.toByteArray(Charset.forName("UTF-8")),
+          MIMEType("application", "json", mapOf())
+        )
+      )
+      .build()
+  }
+}

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/DependentsViewModel.kt
@@ -45,7 +45,7 @@ class DependentsViewModel(
 
   //Ekirjasto token returned by circulation
   private lateinit var ekirjastoToken : String
-  //dependent post URI
+  //Dependent post URI
   private lateinit var dependentPostURI: URI
 
   //Error message
@@ -73,8 +73,9 @@ class DependentsViewModel(
   }
 
   /**
-   * Make calls to server to get ekirjasto token, and use it to
-   * get dependents.
+   * Handle the dependents lookup. Function makes a call to circulation to get ekirjasto token,
+   * and uses it to get dependents from API. Updates the found dependents to the observable
+   * dependentList.
    */
   fun lookupDependents() {
     //Get account information

--- a/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
@@ -63,6 +63,13 @@
                 android:layout_height="wrap_content"
                 android:text="@string/account_register_passkey" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonInviteDependents"
+                style="@style/Palace.Button.Outlined.Settings.Arrowed"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/invite_a_dependent" />
+
             <TextView
                 android:id="@+id/eulaStatement"
                 style="@style/Palace.TextViewStyle.Settings"

--- a/simplified-ui-accounts/src/main/res/layout/dependents.xml
+++ b/simplified-ui-accounts/src/main/res/layout/dependents.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="24dp"
+        android:text="@string/invite_a_dependent"
+        android:background="@color/EkirjastoLightGreen"
+        android:textColor="@color/EkirjastoBlack"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.05" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonDependents"
+        style="@style/Palace.Button.Outlined.Settings"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:text="@string/get_dependents"
+        app:layout_constraintTop_toBottomOf="@+id/textView"
+        />
+
+    <ProgressBar
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/dependentsLoading"
+        app:layout_constraintTop_toBottomOf="@id/buttonDependents"/>
+
+    <Spinner
+        android:id="@+id/spinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="18dp"
+        app:layout_constraintTop_toBottomOf="@id/dependentsLoading"
+        tools:layout_editor_absoluteX="-78dp" />
+
+    <EditText
+        android:id="@+id/email"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/dependent_email"
+        android:inputType="textEmailAddress"
+        android:padding="20dp"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/dependentInfoText" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/send"
+        style="@style/Palace.Button.Outlined.Settings"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:text="@string/send_invitation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/email" />
+
+    <TextView
+        android:id="@+id/dependentInfoText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/EkirjastoLightestGrey"
+        android:padding="20dp"
+        android:text="@string/guidetext"
+        android:textAlignment="center"
+        android:textColor="@color/EkirjastoBlack"
+        android:textSize="12sp"
+        app:layout_constraintTop_toBottomOf="@id/spinner" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/invMoreDependents"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        style="@style/Palace.Button.Outlined.Settings"
+        app:layout_constraintTop_toBottomOf="@id/dependentInfoText"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginTop="8dp"
+        android:text="@string/invite_another_dependent"/>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/simplified-ui-accounts/src/main/res/layout/dependents.xml
+++ b/simplified-ui-accounts/src/main/res/layout/dependents.xml
@@ -26,7 +26,6 @@
         style="@style/Palace.Button.Outlined.Settings"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textSize="12sp"
         android:text="@string/get_dependents"
         app:layout_constraintTop_toBottomOf="@+id/textView"
         />
@@ -52,7 +51,6 @@
         android:hint="@string/dependent_email"
         android:inputType="textEmailAddress"
         android:padding="20dp"
-        android:textSize="12sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/dependentInfoText" />
 
@@ -61,7 +59,6 @@
         style="@style/Palace.Button.Outlined.Settings"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textSize="12sp"
         android:text="@string/send_invitation"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -76,7 +73,6 @@
         android:text="@string/guidetext"
         android:textAlignment="center"
         android:textColor="@color/EkirjastoBlack"
-        android:textSize="12sp"
         app:layout_constraintTop_toBottomOf="@id/spinner" />
 
     <com.google.android.material.button.MaterialButton

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -107,4 +107,7 @@
   <string name="guidetext">Fill in an email where the invitation should be sent. Make sure to type it in correctly before sending.</string>
   <string name="thanks">Thank you! Your dependent should receive the invitation shortly if the email was entered correctly.</string>
   <string name="emailNotValid">Enter a Valid Email Address.</string>
+  <string name="errorFromServer">Something went wrong. Sign out and back in and try again.</string>
+  <string name="errorInCreation">Could not finish request. Check internet connection and try again.</string>
+
 </resources>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -105,7 +105,7 @@
   <string name="invite_another_dependent">Invite another Dependent</string>
   <string name="no_dependents">No dependents or children found.</string>
   <string name="guidetext">Fill in an email where the invitation should be sent. Make sure to type it in correctly before sending.</string>
-  <string name="thanks">Thank you! Your dependent should receive the invitation shortly if the email was entered correctly.\n\nThe link should be opened on their personal device. The link leads to website where they can register a passkey. This passkey is can be used to enter e-kirjasto.</string>
+  <string name="thanks">Thank you! Your dependent should receive the invitation shortly if the email was entered correctly.\n\nThe link should be opened on their personal device. The link leads to website where they can register a passkey. This passkey can be used to enter e-kirjasto.</string>
   <string name="emailNotValid">Enter a Valid Email Address.</string>
   <string name="errorFromServer">Something went wrong. Sign out and back in and try again.</string>
   <string name="errorInCreation">Could not finish request. Check internet connection and try again.</string>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -97,4 +97,14 @@
   <string name="errorPasskeyLoginFailed">Could not sign in with Passkey</string>
   <string name="errorPasskeyRegisterFailed">Error registering a Passkey</string>
   <string name="errorSuomiFiLoginFailed">Could not sign in with Suomi.fi</string>
+  <string name="invite_a_dependent">Invite a Dependent</string>
+  <string name="get_dependents">Get Dependents or Children</string>
+  <string name="dependent_email">Dependent email</string>
+  <string name="send_invitation">Send Invitation</string>
+  <string name="select_dependent">Select a Dependent</string>
+  <string name="invite_another_dependent">Invite another Dependent</string>
+  <string name="no_dependents">No dependents or children found.</string>
+  <string name="guidetext">Fill in an email where the invitation should be sent. Make sure to type it in correctly before sending.</string>
+  <string name="thanks">Thank you! Your dependent should receive the invitation shortly if the email was entered correctly.</string>
+  <string name="emailNotValid">Enter a Valid Email Address.</string>
 </resources>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -105,7 +105,7 @@
   <string name="invite_another_dependent">Invite another Dependent</string>
   <string name="no_dependents">No dependents or children found.</string>
   <string name="guidetext">Fill in an email where the invitation should be sent. Make sure to type it in correctly before sending.</string>
-  <string name="thanks">Thank you! Your dependent should receive the invitation shortly if the email was entered correctly.</string>
+  <string name="thanks">Thank you! Your dependent should receive the invitation shortly if the email was entered correctly.\n\nThe link should be opened on their personal device. The link leads to website where they can register a passkey. This passkey is can be used to enter e-kirjasto.</string>
   <string name="emailNotValid">Enter a Valid Email Address.</string>
   <string name="errorFromServer">Something went wrong. Sign out and back in and try again.</string>
   <string name="errorInCreation">Could not finish request. Check internet connection and try again.</string>


### PR DESCRIPTION
This pr adds the dependents fragment and all
its functionalities. The fragment creation is
triggered on the settings page, with a button
placed under passkey creation. The button is
only shown when logged in.

The fragment consists of a button to get the dependents,
an info box to present different information to the user,
email field to enter the email to, and a button to post it,
as well as a button to return to add another dependents.

The get and post calls are handled in the
DependentsViewModel, and the fragment observes both error
and dependents data. When getting dependents, a call to
the circulation to get the fresh ekirjastoToken is made
and then to the backend to get the dependents.

The post is made by adding the dependent in the
body of the request. We assume the child's language
should be the same as the parent's.

From the circulation login we now extract
patronpermanentID along with the circulation token.

This pr also adds the handling of two new
authentication_document links. One is for the dependent
lookup, other for the post. They are added into
the AccountProvidersJSON,
AccountAuthenticationCredentialsJSON and
AccountProviderAuthenticationDescription.

NOTE: As said in Magazine implementation pr, changing
the authentication_document causes the one in memory
to become stale. Error on boot happens because of it,
but only once. If the app is restarted, this is fixed,
but this happens for all users with old cache.
This is helped by clearing app data, but a better
handling needs to be done. Added a ticket for it.

REF: EKIR-235
