### PR TITLE
Ekir 338 reload loans and reservations always on login

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
@@ -181,8 +181,20 @@ class CatalogFeedViewModel(
           ownership.accountId == accountID &&
           feedState is CatalogFeedState.CatalogFeedLoadFailed &&
           feedState.failure is FeedLoaderResult.FeedLoaderFailure.FeedLoaderFailedAuthentication
-        ) {
-          this.logger.debug("reloading feed due to successful login")
+        )  {
+          //Happens only on very specific situation when there is a catalog load fail, caused by authentication
+          this.logger.debug("reloading feed due to successful login after authentication fail")
+          this.reloadFeed()
+        }
+        if ( accountState is AccountLoginState.AccountNotLoggedIn) {
+          this.logger.debug("reloading feed due to log out")
+          this.reloadFeed()
+        }
+        if (accountState is AccountLoginState.AccountLoggedIn) {
+          //We reload feed on login since in some login cases,
+          //(in cases where there are books stored on the device)
+          //the feed shows up empty despite there being loans due to not being updated on login
+          logger.debug("reloading feed due to successful login")
           this.reloadFeed()
         }
         if ( accountState is AccountLoginState.AccountNotLoggedIn) {

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
@@ -197,10 +197,6 @@ class CatalogFeedViewModel(
           logger.debug("reloading feed due to successful login")
           this.reloadFeed()
         }
-        if ( accountState is AccountLoginState.AccountNotLoggedIn) {
-          this.logger.debug("reloading feed due to log out")
-          this.reloadFeed()
-        }
       }
       CatalogFeedOwnership.CollectedFromAccounts -> {
         if (


### PR DESCRIPTION
Usually login triggers a catalog reload, but it
is not triggered from the viewmodel. So sometimes
the loans/reservations view shows empty despite there being 
books on loan/reserve.

The catalog feed reload is done now on login. It is triggered 1-3 times during the login (for some reason) but it only gets the remote feed once and the other times are local feed, so the remote is not called more times than before. Also, in the CatalogFeedOwnership.CollectedFromAccounts case right below this code, the states are handled the same way.

REF: EKIR-338