### PR TITLE
EKIR-341 Add audiobook manifest to memory on book load

### DIFF
--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
@@ -242,6 +242,7 @@ internal class DatabaseFormatHandleAudioBook internal constructor(
     data: ByteArray,
     manifestURI: URI
   ) {
+    logger.debug("Copy manifest and URI to memory")
     val newFormat = synchronized(this.dataLock) {
       FileUtilities.fileWriteBytes(
         data, this.fileManifest

--- a/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -208,10 +208,10 @@ class AudioBookPlayerActivity :
     val a = i.extras!!
 
     this.parameters = a.getSerializable(PARAMETER_ID) as? AudioBookPlayerParameters ?: kotlin.run {
-      val title = this.getString(R.string.audio_book_player_error_book_open)
+      val title = this.getString(R.string.audio_book_player_error_book_open_data_missing)
       this.showErrorWithRunnable(
         context = this,
-        title = title,
+        message = title,
         failure = IllegalStateException(title),
         execute = this::finish
       )
@@ -266,10 +266,10 @@ class AudioBookPlayerActivity :
         .findFormatHandle(BookDatabaseEntryFormatHandleAudioBook::class.java)
 
     if (formatHandleOpt == null) {
-      val title = this.getString(R.string.audio_book_player_error_book_open)
+      val title = this.getString(R.string.audio_book_player_error_book_open_database_error)
       this.showErrorWithRunnable(
         context = this,
-        title = title,
+        message = title,
         failure = IllegalStateException(title),
         execute = this::finish
       )
@@ -412,7 +412,7 @@ class AudioBookPlayerActivity :
   override fun onLoadingFragmentLoadingFailed(exception: Exception) {
     this.showErrorWithRunnable(
       context = this,
-      title = exception.message ?: "",
+      message = exception.message ?: "",
       failure = exception,
       execute = this::finish
     )
@@ -459,7 +459,7 @@ class AudioBookPlayerActivity :
       val title = this.getString(R.string.audio_book_player_error_engine_open)
       this.showErrorWithRunnable(
         context = this,
-        title = title,
+        message = title,
         failure = IllegalStateException(title),
         execute = this::finish
       )
@@ -493,7 +493,7 @@ class AudioBookPlayerActivity :
       val title = this.getString(R.string.audio_book_player_error_book_open)
       this.showErrorWithRunnable(
         context = this,
-        title = title,
+        message = title,
         failure = bookResult.failure,
         execute = this::finish
       )
@@ -1123,11 +1123,11 @@ class AudioBookPlayerActivity :
 
   private fun showErrorWithRunnable(
     context: Activity,
-    title: String,
+    message: String,
     failure: Exception,
     execute: () -> Unit
   ) {
-    this.log.error("error: {}: ", title, failure)
+    this.log.error("error: {}: ", message, failure)
 
     this.uiThread.runOnUIThread {
       if (context.isDestroyed || context.isFinishing) {
@@ -1135,8 +1135,8 @@ class AudioBookPlayerActivity :
       }
 
       MaterialAlertDialogBuilder(context)
-        .setTitle(title)
-        .setMessage(failure.localizedMessage)
+        .setTitle(getString(R.string.audio_book_player_error_book_open))
+        .setMessage(message)
         .setOnDismissListener {
           execute.invoke()
         }

--- a/simplified-viewer-audiobook/src/main/res/values/strings.xml
+++ b/simplified-viewer-audiobook/src/main/res/values/strings.xml
@@ -9,7 +9,10 @@
   <string name="audio_book_player_do_keep">Keep</string>
   <string name="audio_book_player_do_return">Return</string>
   <string name="audio_book_player_error_book_open">Unable to open audio book</string>
-  <string name="audio_book_player_error_engine_open">Unable to initialize audio engine</string>
+  <string name="audio_book_player_error_book_open_data_missing">Some needed data is missing. Log out and back in and load the book again.</string>
+  <string name="audio_book_player_error_book_open_database_error">The book format is not supported. Please report this book through the feedback form.</string>
+  <string name="audio_book_player_error_book_open_audio">There was an error in creating the audio player.</string>
+  <string name="audio_book_player_error_engine_open">Unable to initialize audio engine.</string>
   <string name="audio_book_player_return_question">Would you like to return it?</string>
   <string name="audio_book_player_return_title">Your Audiobook Has Finished</string>
   <string name="audio_book_player_toc_title">Table Of Contents</string>


### PR DESCRIPTION
Audiobook manifest was saved only on book
open, making closing the app or logging out
before opening the book make the book unusable.
This is now fixed by adding the manifest file to
memory when the book is loaded. The manifest file
is extracted from the zip file and added to local
database.

The errors that audiobook player was giving were
nondiscriptive, so added some new strings to help
with recognizing where the errors are happening.

Also added some logs.

REF: EKIR-341