### PR TITLE
Delete the screen turn interactivity

### DIFF
--- a/simplified-ekirjasto-magazines/src/main/java/fi/kansalliskirjasto/ekirjasto/magazines/MagazinesFragment.kt
+++ b/simplified-ekirjasto-magazines/src/main/java/fi/kansalliskirjasto/ekirjasto/magazines/MagazinesFragment.kt
@@ -181,7 +181,6 @@ class MagazinesFragment : Fragment(R.layout.magazines) {
     readerDialog!!.addContentView(readerWebView!!, paramsWebView)
     readerDialog!!.setOnDismissListener { onReaderClosed() }
     readerDialog!!.show()
-    requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
   }
 
   /**

--- a/simplified-ekirjasto-magazines/src/main/java/fi/kansalliskirjasto/ekirjasto/magazines/MagazinesFragment.kt
+++ b/simplified-ekirjasto-magazines/src/main/java/fi/kansalliskirjasto/ekirjasto/magazines/MagazinesFragment.kt
@@ -106,7 +106,6 @@ class MagazinesFragment : Fragment(R.layout.magazines) {
       logger.debug("Saved latest browser URL: {}", latestUrl.toString())
     }
     readerDialog?.dismiss()
-    requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     super.onStop()
   }
 
@@ -189,7 +188,6 @@ class MagazinesFragment : Fragment(R.layout.magazines) {
   fun closeReader() {
     logger.debug("closeReader()")
     readerDialog?.dismiss()
-    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
   }
 
   /**
@@ -200,7 +198,6 @@ class MagazinesFragment : Fragment(R.layout.magazines) {
     readerWebView?.destroy()
     readerWebView = null
     readerDialog = null
-    activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
   }
 
   private fun getBrowsingUrlBase(): String? {


### PR DESCRIPTION
The screen would turn when phone was flipped,
but we don't want it now so we remove this functionality.

Can be tested by turning the phone when in a magazine view (of one magazine). 
The view should not flip.

REF: EKIR-355