### PR TITLE
Add an information popup when not enough space

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailViewModel.kt
@@ -288,6 +288,13 @@ class CatalogBookDetailViewModel(
     this.borrowViewModel.tryDelete(feedEntry.accountID, feedEntry.bookID)
   }
 
+  /**
+   * Function for cancelling download. Needed because class extends
+   * CatalogPagedViewListener. Function is not used but is functional.
+   */
+  override fun cancelDownload(feedEntry: FeedEntry.FeedEntryOPDS) {
+    this.borrowViewModel.tryCancelDownload(feedEntry.accountID, feedEntry.bookID)
+  }
   override fun resetInitialBookStatus(feedEntry: FeedEntry.FeedEntryOPDS) {
     val initialBookStatus = synthesizeBookWithStatus(feedEntry)
     this.bookRegistry.update(initialBookStatus)

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBorrowViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBorrowViewModel.kt
@@ -281,12 +281,19 @@ class CatalogBorrowViewModel(
     this.booksController.bookRevokeFailedDismiss(accountID, bookID)
   }
 
+  /**
+   * Try cancelling the current download. Cancelling deletes the book from the database,
+   * so after that is done, we sync current books with backend, so a new entry for the
+   * cancelled book is added to database.
+   */
   fun tryCancelDownload(
     accountID: AccountID,
     bookID: BookID
   ) {
     this.logger.debug("cancelling download: {}", bookID)
     this.booksController.bookCancelDownloadAndDelete(accountID, bookID)
+    //In order for the loan view to show books correctly, sync with the backend
+    this.booksController.booksSync(accountID)
   }
 
   fun tryDelete(

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
@@ -1046,6 +1046,16 @@ class CatalogFeedViewModel(
     this.borrowViewModel.tryDelete(feedEntry.accountID, feedEntry.bookID)
   }
 
+  /**
+   * Try to cancel the current download of a book
+   */
+  override fun cancelDownload(feedEntry: FeedEntry.FeedEntryOPDS) {
+    this.borrowViewModel.tryCancelDownload(feedEntry.accountID, feedEntry.bookID)
+    //Since canceling download deletes the book from local database, we need to sync with
+    //the circulation so that the loan is shown correctly
+    this.syncAccounts()
+  }
+
   override fun borrowMaybeAuthenticated(book: Book) {
     this.openLoginDialogIfNecessary(book.account)
     this.borrowViewModel.tryBorrowMaybeAuthenticated(book)

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -1,12 +1,15 @@
 package org.librarysimplified.ui.catalog
 
 import android.content.Context
+import android.os.Environment
+import android.os.StatFs
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.recyclerview.widget.RecyclerView
 import com.google.common.base.Preconditions
@@ -31,6 +34,8 @@ import org.nypl.simplified.opds.core.OPDSAvailabilityMatcherType
 import org.nypl.simplified.opds.core.OPDSAvailabilityOpenAccess
 import org.nypl.simplified.opds.core.OPDSAvailabilityRevoked
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
+import org.slf4j.LoggerFactory
+import java.io.File
 
 /**
  * A view holder for a single cell in an infinitely-scrolling feed.
@@ -44,6 +49,8 @@ class CatalogPagedViewHolder(
   private val bookCovers: BookCoverProviderType,
   private val profilesController: ProfilesControllerType
 ) : RecyclerView.ViewHolder(parent) {
+
+  private val logger = LoggerFactory.getLogger(CatalogPagedViewHolder::class.java)
 
   private var thumbnailLoading: FluentFuture<Unit>? = null
 
@@ -539,6 +546,54 @@ class CatalogPagedViewHolder(
     this.setVisibilityIfNecessary(this.progress, View.VISIBLE)
 
     this.progressText.text = book.book.entry.title
+    //Add an onClick listener to the book cell
+    //that links to the book's detail view
+    val onClick: (View) -> Unit = {
+      logger.debug("Open book detail view")
+      this.listener.openBookDetail(this.feedEntry as FeedEntryOPDS)
+    }
+    //Set the clickable area as the whole cell
+    this.progress.setOnClickListener(onClick)
+
+
+    //Check file size, and show popup if file is too big
+    //Check is done only once for each book download
+
+    //Did somehow skip every now and then the case of totalBytes == 0L
+    //So the check is now done on one of the first packets
+    if (status.currentTotalBytes!! < 10000L) {
+      //Expected size of the book that is downloading
+      val expectedSize = status.expectedTotalBytes
+      //How much space is free on the device
+      val freeSpace = getInternalMem()
+      this.logger.debug("Assumed size of file: {}", formatSize(expectedSize))
+
+      //Never should be null, but needs to be checked
+      if (expectedSize != null) {
+        //If size smaller than internal memory, it should technically fit to memory
+        //If doesn't, user gets shown a popup and download is cancelled
+        if (expectedSize < freeSpace) {
+          logger.debug("Enough space for download")
+          logger.debug("Expected size: {}", expectedSize)
+          logger.debug(
+            "Remaining space: {}",
+            formatSize(freeSpace - expectedSize)
+          )
+        } else {
+          logger.debug("Not enough space for download")
+          logger.debug("Already a popup showing: {}", popUpShown)
+          //We don't want to show multiple popups ontop of one another, so we
+          //Show one if one is not already shown
+          if (!popUpShown) {
+            //Show the popup
+            onFileTooBigToStore(freeSpace, expectedSize - freeSpace)
+            //Cancel the download
+            this.listener.cancelDownload(this.feedEntry as FeedEntryOPDS)
+          }
+        }
+      }
+    }
+
 
     val progressPercent = status.progressPercent?.toInt()
     if (progressPercent != null) {
@@ -549,6 +604,78 @@ class CatalogPagedViewHolder(
     }
   }
 
+  /**
+   * Returns the amount of free internal memory there is on the device.
+   */
+  private fun getInternalMem() : Long {
+    // Fetching internal memory information
+    val iPath: File = Environment.getDataDirectory()
+    val iStat = StatFs(iPath.path)
+    val iBlockSize = iStat.blockSizeLong
+    val iAvailableBlocks = iStat.availableBlocksLong
+
+    //Count and return the available internal memory
+    return iAvailableBlocks * iBlockSize
+  }
+
+  /**
+   * Change the bit presentation of a number to
+   * a better understandable form.
+   * Returns a string with the size suffix added.
+   */
+  private fun formatSize(number : Long?) : String {
+    //Expected size in bits that gets changed to the kilobyte or megabyte presentations
+    var expSize: Long = number?: 0L
+    //Suffix, that is either KB or MB
+    var suffix: String? = null
+    //Divide with 1024 to ge the kilobyte presentation, set the suffix
+    if (expSize >= 1024) {
+      suffix = "KB"
+      expSize /= 1024
+      //If possible, divide again to get megabyte presentation, set the suffix
+      if (expSize >= 1024) {
+        suffix = "MB"
+        expSize /= 1024
+      }
+    }
+    //Make the long value into a string
+    val expSizeString = StringBuilder(expSize.toString())
+    //If there is a suffix, add it to the end of the expSize
+    if (suffix != null) {
+      expSizeString.append(suffix)
+    }
+    //Return the size as string
+    return expSizeString.toString()
+  }
+
+  //Boolean that is used to only show one popup at a time
+  //Only true when there is a popup that is currently shown
+  private var popUpShown = false
+
+  /**
+   * If there is no space for the book on the device, show a popup that informs the user about the
+   * required space.
+   */
+  private fun onFileTooBigToStore(deviceSpace: Long, neededSpace : Long) {
+    //Set the popup as shown
+    popUpShown = true
+    logger.debug("Showing size info")
+    //Show a popup with the device space and needed space
+    val builder: AlertDialog.Builder = AlertDialog.Builder(this.context)
+    builder
+      .setMessage(this.context.getString(
+        R.string.bookNotEnoughSpaceMessage,
+        formatSize(deviceSpace),
+        formatSize(neededSpace)))
+      .setTitle(R.string.bookNotEnoughSpaceTitle)
+      .setPositiveButton(R.string.bookNotEnoughSpaceButton) { dialog, which ->
+        //Set the popup as closed
+        popUpShown = false
+      }
+
+    val dialog: AlertDialog = builder.create()
+    dialog.show()
+  }
   private fun onBookStatusDownloadWaitingForExternalAuthentication(
     book: Book
   ) {

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogPagedViewListener.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogPagedViewListener.kt
@@ -26,6 +26,7 @@ interface CatalogPagedViewListener {
 
   fun delete(feedEntry: FeedEntry.FeedEntryOPDS)
 
+  fun cancelDownload(feedEntry: FeedEntry.FeedEntryOPDS)
   fun borrowMaybeAuthenticated(book: Book)
 
   fun resetInitialBookStatus(feedEntry: FeedEntry.FeedEntryOPDS)

--- a/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
@@ -91,4 +91,7 @@
   <string name="bookReachedLoanLimitDialogMessage">You have reached your loan limit. You cannot borrow anything further until you return something.</string>
   <string name="bookReachedLoanLimitDialogTitle">Loan limit reached.</string>
   <string name="bookReachedLoanLimitDialogButton">OK</string>
+  <string name="bookNotEnoughSpaceTitle">Not enough space!</string>
+  <string name="bookNotEnoughSpaceMessage">File is too big to store on device. Current free space on device: %1$s. \nFree at least %2$s of space to download the book.</string>
+  <string name="bookNotEnoughSpaceButton">Close</string>
 </resources>


### PR DESCRIPTION
Added a popup that is shown when a book that is downloading is too big to fit on the device. This popup is shown both in single book view as well as the catalog. The popup also interrupts the download. The popup informs user about the remaining free space on their device, as well as how much more space they need to free to be able to load the book.

Canceling a download causes the book to be removed from the local database, and thus the loans page would incorrectly not show the book as one of your loans. This is now fixed by syncing the account with the backend when a download is cancelled (either by the user or the file being too big). The sync gets the user's loan information from the backend and thus updates the local database with correct information.

Also added a onClick listener to the loading cell in the catalog view, so that user can navigate to the bookDetail view even when the book is loading.

Deleted the creation of an empty button space left of the load button, that is useless and places the load button to incorrect spot.

REF EKIR-326

**How should this be tested? / Do these changes have associated tests?**
The popup can be tested by loaning a book that is too big for the device, Ylpeys ja ennakkoluulo seemed to work at least for me. Then when downloading the book from either single book view or the catalog, there should be a popup, and after closing it, the book should still be found in the loans.
The loans page showing up correctly after cancelling download can be tested by loaning a book that fits, and pressing the cancel button during download.
The link to the book detail view can be tested by pressing the downloading book from the catalog view,and it should open the book detail view.

NOTE: There is now repetitive code, should maybe be moved to its own util class?