### PR TITLE
Ekir 377 363 375 change catalog cell layout

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/PreferencesFragment.kt
@@ -122,9 +122,11 @@ class PreferencesFragment : Fragment(R.layout.account_resources) {
       .setPositiveButton(R.string.restartPopupAgree) { dialog, which ->
         //Set locale to the wanted language to be used on restart
         LocaleHelper.setLocale(this.requireContext(), language)
+        dialog.dismiss()
       }
       .setNegativeButton(R.string.restartPopupCancel) { dialog, which ->
         //do nothing
+        dialog.dismiss()
       }
 
     val dialog: AlertDialog = builder.create()

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookAvailabilityStrings.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookAvailabilityStrings.kt
@@ -240,7 +240,7 @@ object CatalogBookAvailabilityStrings {
     return String.format("%d %s", TimeUnit.HOURS.toDays(hours), base)
   }
   /**
-   * Construct a short time interval string like "3 w´d", with units up to days, that will be used
+   * Construct a short time interval string like "3 d", with units up to days, that will be used
    * to show the user the duration of a book's hold.
    *
    * @param resources The application resources

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookAvailabilityStrings.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookAvailabilityStrings.kt
@@ -74,6 +74,44 @@ object CatalogBookAvailabilityStrings {
     return resources.getString(R.string.catalogBookAvailabilityRevoked)
   }
 
+  /**
+   * Returns a short form of the reserved book's hold information.
+   * Function is public so it can be called past the bookStatus check,
+   * but the book needs to be in status BookStatus.Held.HeldInQueue.
+   */
+  fun onHeldShort(
+    resources: Resources,
+    status: BookStatus.Held.HeldInQueue
+  ): String {
+    val queuePositionOpt : OptionType<Int> = Option.of(status.queuePosition)
+    val endDateOpt : OptionType<DateTime> = Option.of(status.endDate)
+    /*
+     * If there is an availability date, show this in preference to
+     * anything else.
+     */
+    if (endDateOpt is Some<DateTime>) {
+      val endDate = endDateOpt.get()
+      val now = DateTime.now()
+      return resources.getString(
+        R.string.catalogBookAvailabilityHeldTimedShort,
+        this.intervalStringHoldDuration(resources, now, endDate)
+      )
+    }
+
+    /*
+     * If there is a queue position, attempt to show this instead.
+     */
+
+    if (queuePositionOpt is Some<Int>) {
+      return resources.getString(R.string.catalogBookAvailabilityHeldQueueShort, queuePositionOpt.get())
+    }
+
+    /**
+     * Otherwise, show an indefinite hold.
+     */
+
+    return resources.getString(R.string.catalogBookAvailabilityHeldIndefiniteShort)
+  }
   private fun onOpenAccess(resources: Resources): String {
     return resources.getString(R.string.catalogBookAvailabilityOpenAccess)
   }
@@ -200,6 +238,48 @@ object CatalogBookAvailabilityStrings {
 
     val base = resources.getString(R.string.catalogBookIntervalDays)
     return String.format("%d %s", TimeUnit.HOURS.toDays(hours), base)
+  }
+  /**
+   * Construct a short time interval string like "3 w´d", with units up to days, that will be used
+   * to show the user the duration of a book's hold.
+   *
+   * @param resources The application resources
+   * @param lower The lower bound of the time period
+   * @param upper The upper bound of the time period
+   *
+   * @return A time interval string
+   */
+
+  fun intervalStringHoldDuration(
+    resources: Resources,
+    lower: DateTime,
+    upper: DateTime
+  ): String {
+    val hours = this.calendarHoursBetween(lower, upper)
+    val days = TimeUnit.HOURS.toDays(hours)
+
+    val unit: String
+    val value: Long
+
+    when {
+      // Switch to days after 48 hours.
+      days >= 2 -> {
+        unit = resources.getString(R.string.catalogBookIntervalDaysShort)
+        value = days
+      }
+
+      // Use hours.
+      hours > 0 -> {
+        unit = resources.getString(R.string.catalogBookIntervalHoursShort)
+        value = hours
+      }
+
+      else -> {
+        return ""
+      }
+    }
+
+    return String.format("%d %s", value, unit)
   }
 
   /**

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -64,6 +64,8 @@ class CatalogPagedViewHolder(
     this.idle.findViewById<TextView>(R.id.bookCellIdleTitle)!!
   private val idleMeta =
     this.idle.findViewById<TextView>(R.id.bookCellIdleMeta)!!
+  private val idleLoanTime =
+    this.idle.findViewById<TextView>(R.id.bookCellIdleLoanTime)!!
   private val idleAuthor =
     this.idle.findViewById<TextView>(R.id.bookCellIdleAuthor)!!
   private val idleButtons =
@@ -288,10 +290,13 @@ class CatalogPagedViewHolder(
     this.setVisibilityIfNecessary(this.error, View.GONE)
     this.setVisibilityIfNecessary(this.idle, View.VISIBLE)
     this.setVisibilityIfNecessary(this.progress, View.GONE)
+    this.setVisibilityIfNecessary(this.idleLoanTime, View.VISIBLE)
 
     this.idleButtons.removeAllViews()
 
     val loanDuration = getLoanDuration(book)
+
+    this.idleLoanTime.text = context.getString(R.string.catalogLoanTime, loanDuration)
 
     this.idleButtons.addView(
       when {
@@ -347,6 +352,7 @@ class CatalogPagedViewHolder(
     this.setVisibilityIfNecessary(this.error, View.GONE)
     this.setVisibilityIfNecessary(this.idle, View.VISIBLE)
     this.setVisibilityIfNecessary(this.progress, View.GONE)
+    this.setVisibilityIfNecessary(this.idleLoanTime, View.GONE)
 
     this.idleButtons.removeAllViews()
     this.idleButtons.addView(
@@ -376,6 +382,7 @@ class CatalogPagedViewHolder(
     this.setVisibilityIfNecessary(this.error, View.GONE)
     this.setVisibilityIfNecessary(this.idle, View.VISIBLE)
     this.setVisibilityIfNecessary(this.progress, View.GONE)
+    this.setVisibilityIfNecessary(this.idleLoanTime, View.GONE)
 
     this.idleButtons.removeAllViews()
     this.idleButtons.addView(
@@ -395,6 +402,15 @@ class CatalogPagedViewHolder(
     this.setVisibilityIfNecessary(this.error, View.GONE)
     this.setVisibilityIfNecessary(this.idle, View.VISIBLE)
     this.setVisibilityIfNecessary(this.progress, View.GONE)
+    this.setVisibilityIfNecessary(this.idleLoanTime, View.GONE)
+
+    //Do we show how long it's still available the loan?
+    /* TODO:THIS
+    this.idleLoanTime.text =
+      CatalogBookAvailabilityStrings.statusString(this.context.resources, status)
+
+     */
+
 
     this.idleButtons.removeAllViews()
     this.idleButtons.addView(
@@ -427,7 +443,13 @@ class CatalogPagedViewHolder(
     this.setVisibilityIfNecessary(this.error, View.GONE)
     this.setVisibilityIfNecessary(this.idle, View.VISIBLE)
     this.setVisibilityIfNecessary(this.progress, View.GONE)
+    this.setVisibilityIfNecessary(this.idleLoanTime, View.GONE)
 
+    //Do we show how long it's still available the loan?
+    /* TODO: Show how long till loanable
+    this.idleLoanTime.text =
+      CatalogBookAvailabilityStrings.statusString(this.context.resources, status)
+    */
     this.idleButtons.removeAllViews()
     if (status.isRevocable) {
       this.idleButtons.addView(
@@ -452,13 +474,17 @@ class CatalogPagedViewHolder(
     this.setVisibilityIfNecessary(this.error, View.GONE)
     this.setVisibilityIfNecessary(this.idle, View.VISIBLE)
     this.setVisibilityIfNecessary(this.progress, View.GONE)
+    this.setVisibilityIfNecessary(this.idleLoanTime, View.VISIBLE)
+
+    val loanDuration = getLoanDuration(book)
+
+    this.idleLoanTime.text = context.getString(R.string.catalogLoanTime, loanDuration)
 
     this.idleButtons.removeAllViews()
 
     when (val format = book.findPreferredFormat()) {
       is BookFormat.BookFormatPDF,
       is BookFormat.BookFormatEPUB -> {
-        val loanDuration = getLoanDuration(book)
         this.idleButtons.addView(
           if (loanDuration.isNotEmpty()) {
             this.buttonCreator.createReadButtonWithLoanDuration(loanDuration) {
@@ -475,7 +501,6 @@ class CatalogPagedViewHolder(
         )
       }
       is BookFormat.BookFormatAudioBook -> {
-        val loanDuration = getLoanDuration(book)
         this.idleButtons.addView(
           if (loanDuration.isNotEmpty()) {
             this.buttonCreator.createListenButtonWithLoanDuration(loanDuration) {
@@ -525,6 +550,7 @@ class CatalogPagedViewHolder(
     this.setVisibilityIfNecessary(this.error, View.GONE)
     this.setVisibilityIfNecessary(this.idle, View.VISIBLE)
     this.setVisibilityIfNecessary(this.progress, View.GONE)
+    this.setVisibilityIfNecessary(this.idleLoanTime, View.GONE)
 
     this.idleButtons.removeAllViews()
   }
@@ -583,6 +609,7 @@ class CatalogPagedViewHolder(
     this.setVisibilityIfNecessary(this.error, View.GONE)
     this.setVisibilityIfNecessary(this.idle, View.GONE)
     this.setVisibilityIfNecessary(this.progress, View.GONE)
+    this.setVisibilityIfNecessary(this.idleLoanTime, View.GONE)
 
     this.errorDetails.setOnClickListener(null)
     this.errorDismiss.setOnClickListener(null)

--- a/simplified-ui-catalog/src/main/res/layout/book_cell_error.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_cell_error.xml
@@ -5,7 +5,8 @@
     android:id="@+id/bookCellError"
     android:background="@drawable/error_border"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/catalogFeedCellHeight">
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/catalogFeedCellHeight">
 
     <TextView
         android:id="@+id/bookCellErrorTitle"
@@ -28,7 +29,7 @@
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
         android:ellipsize="end"
-        android:maxLines="1"
+        android:maxLines="2"
         android:text="@string/catalogOperationFailed"
         android:textStyle="bold"
         app:layout_constraintStart_toStartOf="parent"
@@ -38,7 +39,7 @@
     <LinearLayout
         android:id="@+id/bookCellErrorButtons"
         android:layout_width="0dp"
-        android:layout_height="@dimen/catalogFeedCellButtonsHeight"
+        android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
@@ -47,6 +48,7 @@
         android:weightSum="3"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/bookCellErrorMessage"
         app:layout_constraintEnd_toEndOf="parent">
 
         <Button

--- a/simplified-ui-catalog/src/main/res/layout/book_cell_idle.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_cell_idle.xml
@@ -10,12 +10,11 @@
 
     <ImageView
         android:id="@+id/bookCellIdleCover"
-        android:layout_width="@dimen/catalogFeedCellImageWidth"
-        android:layout_height="0dp"
+        android:layout_width="@dimen/cover_thumbnail_height"
+        android:layout_height="match_parent"
         android:layout_marginStart="16dp"
         android:contentDescription="@null"
         android:scaleType="fitStart"
-        app:layout_constraintBottom_toBottomOf="@+id/bookCellIdleButtons"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/bookCellIdleTitle" />
 
@@ -33,7 +32,7 @@
         android:id="@+id/bookCellIdleTitle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
+        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="16dp"
         android:ellipsize="end"
@@ -51,7 +50,7 @@
         android:id="@+id/bookCellIdleAuthor"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
+        android:layout_marginStart="8dp"
         android:layout_marginEnd="16dp"
         android:ellipsize="end"
         android:maxLines="1"
@@ -65,7 +64,7 @@
         android:id="@+id/bookCellIdleMeta"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
+        android:layout_marginStart="8dp"
         android:layout_marginEnd="16dp"
         android:ellipsize="end"
         android:maxLines="1"
@@ -82,14 +81,15 @@
         android:layout_height="@dimen/catalogFeedCellButtonsHeight"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
+        android:layout_marginTop="8dp"
         android:layout_marginBottom="10dp"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:weightSum="2"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/bookCellIdleMeta"
+        app:layout_constraintTop_toBottomOf="@id/bookCellIdleCover"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/bookCellIdleCover">
+        app:layout_constraintStart_toStartOf="parent">
 
         <!-- These views are removed at runtime and are just present for the sake of the UI editor preview -->
 

--- a/simplified-ui-catalog/src/main/res/layout/book_cell_idle.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_cell_idle.xml
@@ -8,6 +8,15 @@
     android:minHeight="@dimen/catalogFeedCellHeight"
     android:layout_height="wrap_content">
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/IdleBookWindow"
+        app:layout_constraintTop_toTopOf="parent"
+        android:focusable="true"
+        android:clipChildren="false"
+        android:clipToPadding="false">
+
     <ImageView
         android:id="@+id/bookCellIdleCover"
         android:layout_width="@dimen/cover_thumbnail_height"
@@ -37,7 +46,7 @@
         android:layout_marginEnd="16dp"
         android:ellipsize="end"
         android:includeFontPadding="false"
-        android:maxLines="1"
+        android:maxLines="2"
         android:textSize="16sp"
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
@@ -53,7 +62,7 @@
         android:layout_marginStart="8dp"
         android:layout_marginEnd="16dp"
         android:ellipsize="end"
-        android:maxLines="1"
+        android:maxLines="2"
         android:textSize="14sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
@@ -81,19 +90,24 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="16dp"
-        android:textSize="14sp"
-        android:textColor="@color/EkirjastoBlack"
         android:background="@color/EkirjastoYellow"
-        android:gravity="bottom"
+        android:textColor="@color/EkirjastoBlack"
+        android:textSize="14sp"
+        android:paddingHorizontal="2dp"
+        android:ellipsize="end"
+        android:maxLines="2"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/IdleBookWindow"
         app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
-        app:layout_constraintBottom_toBottomOf="@id/bookCellIdleCover"
+        app:layout_constraintTop_toBottomOf="@id/bookCellIdleMeta"
+        app:layout_constraintVertical_bias="1.0"
         tools:text="Book on loan for 12 days" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <LinearLayout
         android:id="@+id/bookCellIdleButtons"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/catalogFeedCellButtonsHeight"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginTop="8dp"
@@ -101,8 +115,7 @@
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:weightSum="2"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/bookCellIdleCover"
+        app:layout_constraintTop_toBottomOf="@id/IdleBookWindow"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
 
@@ -157,6 +170,6 @@
         android:layout_marginEnd="16dp"
         android:layout_weight="1"
         android:background="@color/colorEkirjastoDivider"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintTop_toBottomOf="@id/bookCellIdleButtons"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/simplified-ui-catalog/src/main/res/layout/book_cell_idle.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_cell_idle.xml
@@ -75,6 +75,21 @@
         app:layout_constraintTop_toBottomOf="@id/bookCellIdleAuthor"
         tools:text="eBook - The New York Public Library" />
 
+    <TextView
+        android:id="@+id/bookCellIdleLoanTime"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="16dp"
+        android:textSize="14sp"
+        android:textColor="@color/EkirjastoBlack"
+        android:background="@color/EkirjastoYellow"
+        android:gravity="bottom"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
+        app:layout_constraintBottom_toBottomOf="@id/bookCellIdleCover"
+        tools:text="Book on loan for 12 days" />
+
     <LinearLayout
         android:id="@+id/bookCellIdleButtons"
         android:layout_width="0dp"

--- a/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
@@ -59,6 +59,7 @@
   <string name="catalogLoginRequired">Please sign in to continue.</string>
   <string name="catalogGet">Get</string>
   <string name="catalogHoldCannotCancel">This reservation cannot be cancelled.</string>
+  <string name="catalogLoanTime">On loan for: %1$s</string>
   <string name="catalogInformation">Information</string>
   <string name="catalogListen">Listen</string>
   <string name="catalogMetaCategories">Categories</string>

--- a/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
@@ -24,6 +24,9 @@
   <string name="catalogBookAvailabilityHeldIndefinite">You have this book on hold.</string>
   <string name="catalogBookAvailabilityHeldQueue">You are at position %1$d in the queue for this book.</string>
   <string name="catalogBookAvailabilityHeldTimed">You will be able to borrow this book in %1$s.</string>
+  <string name="catalogBookAvailabilityHeldIndefiniteShort">On hold</string>
+  <string name="catalogBookAvailabilityHeldQueueShort">At position: %1$d</string>
+  <string name="catalogBookAvailabilityHeldTimedShort">Available in: %1$s</string>
   <string name="catalogBookAvailabilityHoldable">All copies of this book are currently on loan.</string>
   <string name="catalogBookAvailabilityLoanable">This book is available to borrow.</string>
   <string name="catalogBookAvailabilityLoanedIndefinite">You have this book on loan.</string>


### PR DESCRIPTION
Increasing the size of the text on the device
caused text to show too little on some of the
buttons. The loan information was also very
small placed on a button and did not adjust in size.

The buttons are now located on their own row below the
cover image.

The loan time is now placed on a text area under the book
meta information in a yellow box. The box remains on the bottom of the
view close to the buttons, close to where the old buttons were.

On reservations, the time till the book is available is shown in
the same yellow box. The time is shown in days, and if under 2
days, in hours.

In order to help the views on smaller screens and bigger text sizes, the
book's name and authors can now extend to two rows before being
ellipsized.

The increasing of text size also affected the error button layout on catalog view
so fixed the view to show the error message in two rows, and having the buttons not 
cover the text by setting the layout_height as wrap_content.

Ref: EKIR-375, EKIR-363, EKIR-377

This code can be tested by takin a loan and a hold and changing the size of the font in the app settings. All texts
should remain visible and neat, and the loan time and on hold timers should show for their respective books.
The error view can be tested by starting a download and then cutting the emulator's internet connection for a moment.
These buttons still look ugly and cut off text on small devices with large font sizes.

TO NOTE: There needs to be done a pr for the theme repo in order to adjust the button paddings so that more text can be shown on the buttons.