### PR TITLE
Pressing loan button opens the login page

### DIFF
--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragment.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragment.kt
@@ -132,6 +132,19 @@ class MainFragment : Fragment(R.layout.main_tabbed_host) {
     )
   }
 
+  /**
+   * Hide bottom tabs from the user
+   */
+  fun hideTabs() {
+    bottomView.visibility = View.GONE
+  }
+
+  /**
+   * Show user the bottom tabs
+   */
+  fun showTabs() {
+    bottomView.visibility = View.VISIBLE
+  }
   override fun onOptionsItemSelected(item: MenuItem): Boolean {
     return when (item.itemId) {
       android.R.id.home -> {

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragment.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragment.kt
@@ -133,16 +133,16 @@ class MainFragment : Fragment(R.layout.main_tabbed_host) {
   }
 
   /**
-   * Hide bottom tabs from the user
+   * Hide bottom navigation menu from the user
    */
-  fun hideTabs() {
+  fun hideBottomNavigationMenu() {
     bottomView.visibility = View.GONE
   }
 
   /**
-   * Show user the bottom tabs
+   * Show user the bottom navigation menu
    */
-  fun showTabs() {
+  fun showBottomNavigationMenu() {
     bottomView.visibility = View.VISIBLE
   }
   override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
@@ -15,6 +15,7 @@ import org.librarysimplified.ui.catalog.CatalogFeedArguments
 import org.librarysimplified.ui.catalog.CatalogFeedEvent
 import org.librarysimplified.ui.catalog.CatalogFeedFragment
 import org.librarysimplified.ui.catalog.saml20.CatalogSAML20Event
+import org.librarysimplified.ui.login.LoginMainFragment
 import org.librarysimplified.ui.navigation.tabs.TabbedNavigator
 import org.librarysimplified.viewer.preview.BookPreviewActivity
 import org.nypl.simplified.accounts.api.AccountID
@@ -82,6 +83,12 @@ internal class MainFragmentListenerDelegate(
 
     activity.onBackPressedDispatcher.addCallback(this.fragment) {
       if (navigator.popBackStack()) {
+        //Use the current fragment as Main Fragment so we get
+        //to use the showTabs() function
+        val loginFragment = fragment as MainFragment
+        //Ensure the tabs are shown when pressed back
+        //Only changes something if the shown view is the login fragment where there is no tabs visible
+        loginFragment.showTabs()
         return@addCallback
       }
 
@@ -216,12 +223,7 @@ internal class MainFragmentListenerDelegate(
   ): MainFragmentState {
     return when (event) {
       is CatalogFeedEvent.LoginRequired -> {
-        this.openSettingsAccount(
-          event.account,
-          comingFromBookLoanRequest = true,
-          comingFromDeepLink = false,
-          barcode = null
-        )
+        this.openLogin()
         MainFragmentState.CatalogWaitingForLogin
       }
 
@@ -258,12 +260,7 @@ internal class MainFragmentListenerDelegate(
   ): MainFragmentState {
     return when (event) {
       is CatalogBookDetailEvent.LoginRequired -> {
-        this.openSettingsAccount(
-          event.account,
-          comingFromBookLoanRequest = true,
-          comingFromDeepLink = false,
-          barcode = null
-        )
+        this.openLogin()
         MainFragmentState.BookDetailsWaitingForLogin
       }
 
@@ -746,6 +743,19 @@ internal class MainFragmentListenerDelegate(
     else {
       openSettingsAccounts()
     }
+  }
+
+  private fun openLogin() {
+    this.logger.debug("openLogin")
+    //Add the login fragment, the tab isn't showing so it can be the current one
+    this.navigator.addFragment(
+      fragment = LoginMainFragment.create(),
+      tab = this.navigator.currentTab()
+    )
+    //Use the current fragment as Main Fragment so we get
+    //to use the hideTabs() function
+    val loginFragment = this.fragment as MainFragment
+    loginFragment.hideTabs()
   }
 
   private fun openSettingsAccount(

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragmentListenerDelegate.kt
@@ -88,7 +88,7 @@ internal class MainFragmentListenerDelegate(
         val loginFragment = fragment as MainFragment
         //Ensure the tabs are shown when pressed back
         //Only changes something if the shown view is the login fragment where there is no tabs visible
-        loginFragment.showTabs()
+        loginFragment.showBottomNavigationMenu()
         return@addCallback
       }
 
@@ -755,7 +755,7 @@ internal class MainFragmentListenerDelegate(
     //Use the current fragment as Main Fragment so we get
     //to use the hideTabs() function
     val loginFragment = this.fragment as MainFragment
-    loginFragment.hideTabs()
+    loginFragment.hideBottomNavigationMenu()
   }
 
   private fun openSettingsAccount(

--- a/simplified-ui-tutorial/src/main/java/org/librarysimplified/ui/login/LoginMainFragment.kt
+++ b/simplified-ui-tutorial/src/main/java/org/librarysimplified/ui/login/LoginMainFragment.kt
@@ -56,6 +56,12 @@ class LoginMainFragment : Fragment(R.layout.login_main_fragment) {
   override val defaultViewModelProviderFactory: ViewModelProvider.Factory
     get() = this.defaultViewModelFactory
 
+  companion object {
+  fun create(): LoginMainFragment {
+    val fragment = LoginMainFragment()
+    return fragment
+  }
+}
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     logger.debug("onViewCreated(), recreating: {}", (savedInstanceState != null))
     super.onViewCreated(view, savedInstanceState)


### PR DESCRIPTION
Pressing loan button when not logged in used
to throw  the user into the settings page.

This change makes it so that the user is shown
the login page when the loan/reserve button is
clicked when not logged in.

When the fragment is showing, we hide the bottom
toolbar, so the view looks as close to possible
to the login screen you see when you open the
application. The only difference is the green
line shown on the bottom of the screen.
To ensure that the toolbar buttons are shown
correctly when pressing the back button and closing 
the login screen, we set pressing the back button in the main 
fragment to make the buttons visible.

TONOTE: Logging in empties our backstack and always shows the catalog when the login is finished.
Thus after loging in, the user isn't returned to the book they started the login from, and pressing the back button in that situation causes the app to close. This behaviour is not different from the original behaviour, but should be rectified for better user experience.

REF: EKIR-366, EKIRJASTO-70

Can be tested by pressing the loan buttons on the single book view and on the catalog view. The login page should pop up and the bottom buttons should disappear. The buttons should reappear when pressing the back button or logging in. 

Does not need Transifex updates.
