### PR TITLE
Change MainApplication instance init spot

### DIFF
--- a/simplified-main/src/main/java/org/librarysimplified/main/MainApplication.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainApplication.kt
@@ -47,6 +47,7 @@ class MainApplication : Application() {
   override fun onCreate() {
     super.onCreate()
 
+    INSTANCE = this
     MainLogging.configure(cacheDir)
 
     AppInfoUtil.init(this)
@@ -68,7 +69,6 @@ class MainApplication : Application() {
     this.logStartup()
     MainTransifex.configure(this.applicationContext)
     this.boot.start(this)
-    INSTANCE = this
   }
 
   private fun logStartup() {


### PR DESCRIPTION
There was crashes that were seemingly caused by
boot fragment calling the mainApplication instance before the value for the INSTANCE was set, so
this pr moves the initialisation of the instance
to the earliest spot in the onCreate.

As we were unable to recreate the crash, and the crash was most likely invisible to the user, there was no way to verify that this fixes the error, but the app works normally.

REF: EKIRJASTO-68