### PR TITLE
Ekirjasto 90 allow screen rotation

### DIFF
--- a/simplified-app-ekirjasto/src/main/AndroidManifest.xml
+++ b/simplified-app-ekirjasto/src/main/AndroidManifest.xml
@@ -28,7 +28,9 @@
       android:name="org.librarysimplified.main.MainActivity"
       android:exported="true"
       android:screenOrientation="fullUser"
-      android:launchMode="singleTop">
+        android:configChanges="orientation|screenSize"
+        android:theme="@style/PalaceTheme.WithoutActionBar"
+        android:launchMode="singleTop">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
@@ -83,6 +85,7 @@
     <activity
         android:name="org.librarysimplified.viewer.pdf.pdfjs.PdfReaderActivity"
         android:contentDescription="@string/android_app_name"
+        android:configChanges="orientation|screenSize"
         android:exported="false"
         android:screenOrientation="fullUser"
         android:label="@string/android_app_name" />
@@ -91,6 +94,7 @@
       android:name="org.librarysimplified.viewer.audiobook.AudioBookPlayerActivity"
       android:screenOrientation="fullUser"
       android:exported="false"
+        android:configChanges="orientation|screenSize"
       android:theme="@style/PalaceTheme.WithoutActionBar" />
 
 <!--    <activity-->

--- a/simplified-app-ekirjasto/src/main/AndroidManifest.xml
+++ b/simplified-app-ekirjasto/src/main/AndroidManifest.xml
@@ -28,9 +28,9 @@
       android:name="org.librarysimplified.main.MainActivity"
       android:exported="true"
       android:screenOrientation="fullUser"
-        android:configChanges="orientation|screenSize"
-        android:theme="@style/PalaceTheme.WithoutActionBar"
-        android:launchMode="singleTop">
+      android:configChanges="orientation|screenSize"
+      android:theme="@style/PalaceTheme.WithoutActionBar"
+      android:launchMode="singleTop">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
@@ -94,7 +94,7 @@
       android:name="org.librarysimplified.viewer.audiobook.AudioBookPlayerActivity"
       android:screenOrientation="fullUser"
       android:exported="false"
-        android:configChanges="orientation|screenSize"
+      android:configChanges="orientation|screenSize"
       android:theme="@style/PalaceTheme.WithoutActionBar" />
 
 <!--    <activity-->

--- a/simplified-app-ekirjasto/src/main/AndroidManifest.xml
+++ b/simplified-app-ekirjasto/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
     <activity
       android:name="org.librarysimplified.main.MainActivity"
       android:exported="true"
-      android:screenOrientation="portrait"
+      android:screenOrientation="fullUser"
       android:launchMode="singleTop">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
@@ -63,7 +63,7 @@
         android:name="org.librarysimplified.viewer.preview.BookPreviewActivity"
         android:exported="false"
         android:parentActivityName="org.librarysimplified.main.MainActivity"
-        android:screenOrientation="portrait"
+        android:screenOrientation="fullUser"
         android:theme="@style/PalaceTheme.WithoutActionBar" />
 
     <activity
@@ -71,7 +71,7 @@
       android:configChanges="orientation|keyboardHidden"
       android:exported="false"
       android:parentActivityName="org.librarysimplified.main.MainActivity"
-      android:screenOrientation="portrait"
+      android:screenOrientation="fullUser"
       android:theme="@style/PalaceTheme.WithoutActionBar" />
 
 <!--    <activity-->
@@ -84,12 +84,12 @@
         android:name="org.librarysimplified.viewer.pdf.pdfjs.PdfReaderActivity"
         android:contentDescription="@string/android_app_name"
         android:exported="false"
-        android:screenOrientation="portrait"
+        android:screenOrientation="fullUser"
         android:label="@string/android_app_name" />
 
     <activity
       android:name="org.librarysimplified.viewer.audiobook.AudioBookPlayerActivity"
-      android:screenOrientation="portrait"
+      android:screenOrientation="fullUser"
       android:exported="false"
       android:theme="@style/PalaceTheme.WithoutActionBar" />
 

--- a/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
@@ -405,6 +405,7 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
   private fun configureToolbarActions() {
     this.toolbar.inflateMenu(menu.top_toolbar_menu)
     this.bottomToolbar.inflateMenu(menu.bottom_toolbar_menu)
+
     this.toolbar.setNavigationOnClickListener { this.onToolbarNavigationSelected() }
 
     val backbutton:LinearLayout = this.toolbar.findViewById(org.librarysimplified.viewer.audiobook.R.id.backButton)
@@ -534,7 +535,7 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
     this.playerPosition.isEnabled = false
     this.playerPositionDragging = false
 
-    this.playerPosition.setOnTouchListener { _, event -> this.handleTouchOnSeekbar(event) }
+    this.playerPosition.setOnSeekBarChangeListener(createSeekbarChangeListener())
 
     this.playerTimeCurrent = view.findViewById(R.id.player_time)!!
     this.playerTimeMaximum = view.findViewById(R.id.player_time_maximum)!!
@@ -570,28 +571,35 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
     }
   }
 
-  private fun handleTouchOnSeekbar(event: MotionEvent?): Boolean {
-    return when (event?.action) {
-      MotionEvent.ACTION_DOWN -> {
-        this.playerPositionDragging = true
-        this.playerPosition.onTouchEvent(event)
-      }
+  /**
+   * Create a new OnSeekbarChangeListener
+   */
+  private fun createSeekbarChangeListener(): SeekBar.OnSeekBarChangeListener {
+    return object : SeekBar.OnSeekBarChangeListener {
+      // Handle when the progress changes
+      override fun onProgressChanged(
+        seek: SeekBar,
+        progress: Int, fromUser: Boolean
+      ) {
 
-      MotionEvent.ACTION_UP -> {
-        if (this.playerPositionDragging) {
-          this.playerPositionDragging = false
-          this.onReleasedPlayerPositionBar()
+        // If the change is made by the user, set the player position as dragging
+        // So the thumb follows the user's touch
+        if (fromUser) {
+          playerPositionDragging = true
         }
-        this.playerPosition.onTouchEvent(event)
       }
 
-      MotionEvent.ACTION_CANCEL -> {
-        this.playerPositionDragging = false
-        this.playerPosition.onTouchEvent(event)
+      // Handle when the user starts tracking touch
+      override fun onStartTrackingTouch(seek: SeekBar) {
+        // No need to do anything
       }
 
-      else -> {
-        this.playerPosition.onTouchEvent(event)
+      // Handle when the user stops tracking touch
+      override fun onStopTrackingTouch(seek: SeekBar) {
+        // Set the dragging as stopped
+        playerPositionDragging = false
+        // Run the function that moves the player to matching spot with the seekbar
+        onReleasedPlayerPositionBar()
       }
     }
   }

--- a/simplified-viewer-audiobook/src/main/res/layout/ekirjasto_audio_player_view.xml
+++ b/simplified-viewer-audiobook/src/main/res/layout/ekirjasto_audio_player_view.xml
@@ -39,210 +39,287 @@
         </LinearLayout>
     </androidx.appcompat.widget.Toolbar>
 
-    <TextView
-        android:id="@+id/player_title"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:ellipsize="end"
-        android:gravity="center"
-        android:lines="1"
-        android:textSize="22sp"
-        android:textStyle="bold"
-        android:textColor="@color/colorEkirjastoText"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:id="@+id/audiobookScroll"
+        android:fillViewport="true"
         app:layout_constraintTop_toBottomOf="@id/audioBookToolbar"
-        tools:text="Very, very, very long placeholder text that should never be seen in practice." />
+        app:layout_constraintBottom_toTopOf="@id/audioBookBottomToolbar"
+        >
 
-    <TextView
-        android:id="@+id/player_author"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="6dp"
-        android:layout_marginEnd="16dp"
-        android:ellipsize="end"
-        android:gravity="center"
-        android:lines="1"
-        android:textSize="16sp"
-        android:textColor="@color/colorEkirjastoText"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/player_title"
-        tools:text="Very, very, very long placeholder text that should never be seen in practice." />
-
-    <TextView
-        android:id="@+id/player_remaining_book_time"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:gravity="center"
-        android:lines="1"
-        android:textSize="14sp"
-        android:textColor="@color/colorEkirjastoText"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/player_author"
-        tools:text="4 hr 56 min remaining" />
-
-    <SeekBar
-        android:id="@+id/player_progress"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="10dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="10dp"
-        android:progress="0"
-        android:scaleY="1.2"
-        android:thumb="@drawable/seekbar_thumb"
-        android:progressDrawable="@drawable/seekbar_progress_style"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/player_remaining_book_time" />
-
-    <TextView
-        android:id="@+id/player_time"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="26dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/audiobook_player_initial"
-        android:textSize="16sp"
-        android:textColor="@color/colorEkirjastoText"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/player_progress" />
-
-    <TextView
-        android:id="@+id/player_time_maximum"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="26dp"
-        android:text="@string/audiobook_player_initial"
-        android:textSize="16sp"
-        android:textColor="@color/colorEkirjastoText"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/player_progress" />
-
-    <TextView
-        android:id="@+id/player_spine_element"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/player_progress"
-        android:layout_marginTop="8dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:gravity="center"
-        android:textSize="16sp"
-        android:textStyle="bold"
-        android:textColor="@color/colorEkirjastoText"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/player_progress"
-        tools:text="Very, very, very long placeholder text that should never be seen in practice." />
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/player_commands"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="15dp"
-        app:layout_constraintBottom_toTopOf="@id/player_commands_texts">
-
-        <ImageView
-            android:id="@+id/player_play_button"
-            android:layout_width="96dp"
-            android:layout_height="96dp"
-            android:contentDescription="@string/audiobook_accessibility_play"
-            android:src="@drawable/elibrary_play_icon"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:tintMode="src_in" />
-
-        <ImageView
-            android:id="@+id/player_jump_backwards"
-            android:layout_width="64dp"
-            android:layout_height="64dp"
-            android:layout_marginStart="35dp"
-            android:layout_marginBottom="10dp"
-            android:contentDescription="@string/audiobook_accessibility_backward_15"
-            android:src="@drawable/elibrary_rewind_icon"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/player_play_button"
-            app:layout_constraintStart_toStartOf="parent"
-            app:tintMode="src_in" />
-
-        <ImageView
-            android:id="@+id/player_jump_forwards"
-            android:layout_width="64dp"
-            android:layout_height="64dp"
-            android:layout_marginEnd="35dp"
-            android:layout_marginBottom="10dp"
-            android:contentDescription="@string/audiobook_accessibility_forward_15"
-            android:src="@drawable/elibrary_forward_icon"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/player_play_button"
-            app:tintMode="src_in" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/player_commands_texts"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="30dp"
-        app:layout_constraintBottom_toTopOf="@id/bottomDivider">
-
-        <TextView
-            android:id="@+id/player_jump_backwards_text"
-            android:layout_width="wrap_content"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:clickable="false"
-            android:focusable="false"
-            android:gravity="start"
-            android:importantForAccessibility="no"
-            android:text="15 sec."
-            android:textColor="@color/PalaceTextInvertedColor"
-            android:textSize="14sp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/player_play_pause_text"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            app:layout_constraintEnd_toEndOf="@id/audiobookScroll"
+            app:layout_constraintStart_toStartOf="@id/audiobookScroll">
 
-        <TextView
-            android:id="@+id/player_play_pause_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:clickable="false"
-            android:focusable="false"
-            android:gravity="start"
-            android:importantForAccessibility="no"
-            android:text="Play"
-            android:textColor="@color/PalaceTextInvertedColor"
-            android:textSize="14sp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            <TextView
+                android:id="@+id/player_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:ellipsize="end"
+                android:gravity="center"
+                android:lines="1"
+                android:textColor="@color/colorEkirjastoText"
+                android:textSize="22sp"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="Very, very, very long placeholder text that should never be seen in practice." />
 
-        <TextView
-            android:id="@+id/player_jump_forwards_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:clickable="false"
-            android:focusable="false"
-            android:gravity="start"
-            android:importantForAccessibility="no"
-            android:text="15 sec."
-            android:textColor="@color/PalaceTextInvertedColor"
-            android:textSize="14sp"
-            app:layout_constraintStart_toEndOf="@id/player_play_pause_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"/>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <TextView
+                android:id="@+id/player_author"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="6dp"
+                android:layout_marginEnd="16dp"
+                android:ellipsize="end"
+                android:gravity="center"
+                android:lines="1"
+                android:textColor="@color/colorEkirjastoText"
+                android:textSize="16sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/player_title"
+                tools:text="Very, very, very long placeholder text that should never be seen in practice." />
 
+            <TextView
+                android:id="@+id/player_remaining_book_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:gravity="center"
+                android:lines="1"
+                android:textColor="@color/colorEkirjastoText"
+                android:textSize="14sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/player_author"
+                tools:text="4 hr 56 min remaining" />
+
+            <SeekBar
+                android:id="@+id/player_progress"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="10dp"
+                android:progress="0"
+                android:progressDrawable="@drawable/seekbar_progress_style"
+                android:scaleY="1.2"
+                android:thumb="@drawable/seekbar_thumb"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/player_remaining_book_time" />
+
+            <TextView
+                android:id="@+id/player_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="26dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/audiobook_player_initial"
+                android:textColor="@color/colorEkirjastoText"
+                android:textSize="16sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/player_progress" />
+
+            <TextView
+                android:id="@+id/player_time_maximum"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="26dp"
+                android:text="@string/audiobook_player_initial"
+                android:textColor="@color/colorEkirjastoText"
+                android:textSize="16sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/player_progress" />
+
+            <TextView
+                android:id="@+id/player_spine_element"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/player_progress"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:gravity="center"
+                android:textColor="@color/colorEkirjastoText"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/player_progress"
+                tools:text="Very, very, very long placeholder text that should never be seen in practice." />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/player_commands"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="15dp"
+                app:layout_constraintBottom_toTopOf="@id/player_commands_texts">
+
+                <ImageView
+                    android:id="@+id/player_play_button"
+                    android:layout_width="96dp"
+                    android:layout_height="96dp"
+                    android:contentDescription="@string/audiobook_accessibility_play"
+                    android:src="@drawable/elibrary_play_icon"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:tintMode="src_in" />
+
+                <ImageView
+                    android:id="@+id/player_jump_backwards"
+                    android:layout_width="64dp"
+                    android:layout_height="64dp"
+                    android:layout_marginStart="35dp"
+                    android:layout_marginBottom="10dp"
+                    android:contentDescription="@string/audiobook_accessibility_backward_15"
+                    android:src="@drawable/elibrary_rewind_icon"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/player_play_button"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:tintMode="src_in" />
+
+                <ImageView
+                    android:id="@+id/player_jump_forwards"
+                    android:layout_width="64dp"
+                    android:layout_height="64dp"
+                    android:layout_marginEnd="35dp"
+                    android:layout_marginBottom="10dp"
+                    android:contentDescription="@string/audiobook_accessibility_forward_15"
+                    android:src="@drawable/elibrary_forward_icon"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/player_play_button"
+                    app:tintMode="src_in" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/player_commands_texts"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="30dp"
+                app:layout_constraintBottom_toBottomOf="parent">
+
+                <TextView
+                    android:id="@+id/player_jump_backwards_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="false"
+                    android:focusable="false"
+                    android:gravity="start"
+                    android:importantForAccessibility="no"
+                    android:text="15 sec."
+                    android:textColor="@color/PalaceTextInvertedColor"
+                    android:textSize="14sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/player_play_pause_text"
+                    app:layout_constraintStart_toStartOf="parent" />
+
+                <TextView
+                    android:id="@+id/player_play_pause_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="false"
+                    android:focusable="false"
+                    android:gravity="start"
+                    android:importantForAccessibility="no"
+                    android:text="Play"
+                    android:textColor="@color/PalaceTextInvertedColor"
+                    android:textSize="14sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+
+                <TextView
+                    android:id="@+id/player_jump_forwards_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="false"
+                    android:focusable="false"
+                    android:gravity="start"
+                    android:importantForAccessibility="no"
+                    android:text="15 sec."
+                    android:textColor="@color/PalaceTextInvertedColor"
+                    android:textSize="14sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/player_play_pause_text" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/bottom_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="top"
+                app:constraint_referenced_ids="player_commands,player_downloading_chapter" />
+
+            <ProgressBar
+                android:id="@+id/player_downloading_chapter"
+                android:layout_width="64dp"
+                android:layout_height="64dp"
+                android:layout_marginBottom="16dp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                tools:visibility="visible" />
+
+            <TextView
+                android:id="@+id/player_waiting_buffering"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="10dp"
+                android:gravity="center"
+                android:text="@string/audiobook_player_waiting"
+                android:textSize="14sp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toTopOf="@id/bottom_barrier"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <ImageView
+                android:id="@+id/player_cover"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:maxHeight="250dp"
+                android:adjustViewBounds="true"
+                android:layout_margin="16dp"
+                android:contentDescription="@string/audiobook_accessibility_book_cover"
+                android:scaleType="fitCenter"
+                android:src="@drawable/main_icon"
+                app:layout_constraintBottom_toTopOf="@id/player_waiting_buffering"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/player_spine_element" />
+
+            <ImageView
+                android:id="@+id/player_bookmark"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginBottom="16dp"
+                android:alpha="0.5"
+                android:contentDescription="@null"
+                android:focusable="false"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:srcCompat="@drawable/toolbar_bookmark" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
     <View
         android:id="@+id/bottomDivider"
         android:layout_width="match_parent"
@@ -262,64 +339,5 @@
         app:itemIconTint="@color/bottom_toolbar_colors"
         app:itemTextColor="?android:textColorPrimary"
         app:layout_constraintBottom_toBottomOf="parent"/>
-
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/bottom_barrier"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:barrierDirection="top"
-        app:constraint_referenced_ids="player_commands,player_downloading_chapter" />
-
-    <ProgressBar
-        android:id="@+id/player_downloading_chapter"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:layout_marginBottom="16dp"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        tools:visibility="visible" />
-
-    <TextView
-        android:id="@+id/player_waiting_buffering"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="10dp"
-        android:gravity="center"
-        android:text="@string/audiobook_player_waiting"
-        android:textSize="14sp"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toTopOf="@id/bottom_barrier"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <ImageView
-        android:id="@+id/player_cover"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_margin="16dp"
-        android:contentDescription="@string/audiobook_accessibility_book_cover"
-        android:scaleType="fitCenter"
-        android:src="@drawable/main_icon"
-        app:layout_constraintBottom_toTopOf="@id/player_waiting_buffering"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/player_spine_element" />
-
-    <ImageView
-        android:id="@+id/player_bookmark"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginBottom="16dp"
-        android:alpha="0.5"
-        android:contentDescription="@null"
-        android:focusable="false"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:srcCompat="@drawable/toolbar_bookmark" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
@@ -194,27 +194,31 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
       WebView.setWebContentsDebuggingEnabled(true)
     }
 
-    if (savedInstanceState == null) {
-      this.readerFragment =
-        this.supportFragmentManager.fragmentFactory.instantiate(
-          this.classLoader,
-          SR2ReaderFragment::class.java.name
-        )
-      this.searchFragment =
+    //Check if there are fragments with matching tags already in the backstack
+    //If yes, set the existing ones into the variables
+    //If no, initiate a new fragment of the same kind
+      this.readerFragment = this.supportFragmentManager.findFragmentByTag("reader") ?:
+      this.supportFragmentManager.fragmentFactory.instantiate(
+      this.classLoader,
+      SR2ReaderFragment::class.java.name
+      )
+
+      this.searchFragment = this.supportFragmentManager.findFragmentByTag("search") ?:
         this.supportFragmentManager.fragmentFactory.instantiate(
           this.classLoader,
           SR2SearchFragment::class.java.name
         )
-      this.tocFragment =
+
+      this.tocFragment = this.supportFragmentManager.findFragmentByTag("toc") ?:
         this.supportFragmentManager.fragmentFactory.instantiate(
           this.classLoader,
           SR2TOCFragment::class.java.name
         )
 
+    //Add the reader to the stack, add a tag to find the fragment on reconfiguration
       this.supportFragmentManager.beginTransaction()
-        .add(R.id.reader2FragmentHost, this.readerFragment)
+        .add(R.id.reader2FragmentHost, this.readerFragment, "reader")
         .commit()
-    }
   }
 
   override fun onStart() {
@@ -228,7 +232,6 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
     super.onStop()
     this.controllerSubscription?.dispose()
     this.viewSubscription?.dispose()
-
     /*
      * If the activity is finishing, send an analytics event.
      */
@@ -564,13 +567,22 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
 
     this.logger.debug("TOC opening")
 
-    val transaction = this.supportFragmentManager.beginTransaction()
-      .hide(this.readerFragment)
+    // Work around a lifecycle related crash.
+    if (!this::readerFragment.isInitialized) {
+      return
+    }
 
+    //Hide the readerFragment to show the toc
+    val transaction =
+      this.supportFragmentManager.beginTransaction()
+        .hide(this.readerFragment)
+
+    //If a toc has already been added, show it, if not create a new one
     if (this.tocFragment.isAdded) {
       transaction.show(tocFragment)
     } else {
-      transaction.add(R.id.reader2FragmentHost, this.tocFragment)
+      //Add the toc to the stack, add a tag to find the fragment on reconfiguration
+      transaction.add(R.id.reader2FragmentHost, this.tocFragment, "toc")
     }
 
     transaction.commit()
@@ -599,13 +611,16 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
 
     this.logger.debug("Search opening")
 
+    //Hide the reader to show search
     val transaction = this.supportFragmentManager.beginTransaction()
       .hide(this.readerFragment)
 
+    //If there already is a searchFragment in the stack, show it, if not, create a new one
     if (this.searchFragment.isAdded) {
       transaction.show(searchFragment)
     } else {
-      transaction.add(R.id.reader2FragmentHost, this.searchFragment)
+      //Add the search to the stack, add a tag to find the fragment on reconfiguration
+      transaction.add(R.id.reader2FragmentHost, this.searchFragment, "search")
     }
 
     transaction.commit()

--- a/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
@@ -215,10 +215,13 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
           SR2TOCFragment::class.java.name
         )
 
-    //Add the reader to the stack, add a tag to find the fragment on reconfiguration
-      this.supportFragmentManager.beginTransaction()
-        .add(R.id.reader2FragmentHost, this.readerFragment, "reader")
-        .commit()
+    if (savedInstanceState == null) {
+      //If this is the first time using onCreate
+      //Add the reader to the stack, add a tag to find the fragment on reconfiguration
+        this.supportFragmentManager.beginTransaction()
+          .add(R.id.reader2FragmentHost, this.readerFragment, "reader")
+          .commit()
+    }
   }
 
   override fun onStart() {

--- a/simplified-viewer-pdf-pdfjs/src/main/java/org/librarysimplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
+++ b/simplified-viewer-pdf-pdfjs/src/main/java/org/librarysimplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
@@ -122,11 +122,9 @@ class PdfReaderActivity : AppCompatActivity() {
 
   private fun completeReaderSetup(params: PdfReaderParameters, isSavedInstanceStateNull: Boolean) {
     this.loadingBar.visibility = View.GONE
-
-    if (isSavedInstanceStateNull) {
-      createWebView()
-      createPdfServer(params.drmInfo, params.pdfFile)
-    }
+    // Since the views are destroyed on config change, always recreate the webView
+    createWebView()
+    createPdfServer(params.drmInfo, params.pdfFile)
   }
 
   private fun restoreSavedPosition(params: PdfReaderParameters, isSavedInstanceStateNull: Boolean) {


### PR DESCRIPTION
**What's this do?**
This pr enables the screen turning functionality to all of the app views.

**Why are we doing this? (w/ JIRA link if applicable)**
Accessibility requirements demand the turning of the application to be available for all views.

EKIRJASTO-90

**How should this be tested? / Do these changes have associated tests?**
To test this functionalty, enable the screen turning form the device, and test turning the screen in all views, but especially in:

E-book Reader - Should behave normally, and all buttons should work after turning screen while in a book
PDF Reader - Same behavior than above
Audiobook player - Turning the device should not pause the player, and the view becomes scrollable. The spine element should work correctly on user drag and click.
Magazines - Turning should keep the page the magazine is on, and buttons should function as normal.

For the other views, all the navigation buttons (especially the back button) should work on all views even if the screen is turned.

**Dependencies for merging? Releasing to production?**
TO NOTE: This introduces a boot icon that can be seen on app start. This shows the old palace logo. The required changes need to made to ekirjasto-android-theme repository. This will be done on another pr.

**Did someone actually run this code to verify it works?**
Ran on emulator as well as own device.

**Does this require updates to old Transifex strings? Have the translators been informed?**
No translations needed.
