### PR TITLE
EKIRJASTO-194 Fix audiobook crash for newer android versions

### DIFF
--- a/simplified-app-ekirjasto/src/main/AndroidManifest.xml
+++ b/simplified-app-ekirjasto/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" tools:remove="android:maxSdkVersion"/>
   <uses-feature android:name="android.hardware.location.gps" />
 
   <application


### PR DESCRIPTION
In the palace-audiobook library, FOREGROUND_SERVICE_MEDIA_PLAYBACK permission was defined having maxSkdVersion 34, so the permission was not requested for version 35, causing the audiobook to throw an error and crash.

This is fixed by adding the same permission into the app's AndroidManifest and removing the maxSdkVersion, so the permission is asked even on newer versions.

Can be tested with emulator with API 35. Audiobook should open normally and not cause a crash, as well as function normally.

REF: EKIRJASTO-194
