### PR TITLE
Remove maxSdkVersion definition from a permission

### DIFF
--- a/simplified-app-ekirjasto/src/main/AndroidManifest.xml
+++ b/simplified-app-ekirjasto/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" tools:remove="android:maxSdkVersion"/>
   <uses-feature android:name="android.hardware.location.gps" />
 
   <application


### PR DESCRIPTION
In the palace-audiobook library, FOREGROUND_SERVICE_MEDIA_PLAYBACK permission was defined having maxSkdVersion 34, so the permission was not requested for version 35, causing the audiobook to throw an error.

This is fixed by adding the same permission into the app's AndroidManifest and removing the maxSdkVersion, so the permission is asked even on newer versions.

REF: EKIRJASTO-194

**What's this do?**
[Description of what this PR does goes here]

**Why are we doing this? (w/ JIRA link if applicable)**
[Quick blurb about why the code is needed and Jira link goes here / Do these changes meet the business requirements of the story?]

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Have you updated the changelog?**

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**

**Does this require updates to old Transifex strings? Have the translators been informed?**
