### PR TITLE
disable previewButton creation

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -793,7 +793,8 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
   ) {
     this.buttons.removeAllViews()
     
-    val createPreviewButton = bookPreviewStatus != BookPreviewStatus.None
+    //val createPreviewButton = bookPreviewStatus != BookPreviewStatus.None
+    val createPreviewButton = false
 
     when (bookStatus) {
       is BookStatus.Held.HeldInQueue -> {

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -708,8 +708,10 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
   ) {
     this.buttons.removeAllViews()
 
-    val createPreviewButton = bookPreviewStatus != BookPreviewStatus.None
-
+    // Do not createPreviewButton button, regarless of statuses
+    //val createPreviewButton = bookPreviewStatus != BookPreviewStatus.None
+    val createPreviewButton = false
+    
 //    if (createPreviewButton) {
 //      this.buttons.addView(this.buttonCreator.createButtonSpace())
 //    } else {


### PR DESCRIPTION
**What's this do?**
This change disable the preview button functionality by explicitly setting createPreviewButton to false, removing the status-based logic.

**Why are we doing this? (w/ JIRA link if applicable)**
EKIRJASTO-195

**How should this be tested?**
* Verify book detail view loads correctly
* Confirm "View Sample" "Katso näyte" "Visa utdrag" button is not visible.
* Check that all other book detail buttons function normally

