### PR TITLE
Use older ubuntu version for builds

### DIFF
--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/android-pr.yml
+++ b/.github/workflows/android-pr.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Running the builds with the latest ubuntu version requires some changes to be made,
 so for now, use the older version to run our builds.

