### PR TITLE
Replace faq link with user instructions

### DIFF
--- a/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
+++ b/simplified-app-ekirjasto/src/main/java/fi/kansalliskirjasto/ekirjasto/EkirjastoDocumentStoreConfiguration.kt
@@ -43,6 +43,22 @@ class EkirjastoDocumentStoreConfiguration : DocumentConfigurationServiceType {
   override val licenses: DocumentConfiguration? =
     null
 
+  override val instructionsFI: DocumentConfiguration? =
+    DocumentConfiguration(
+      name = null,
+      remoteURI = URI.create("https://www.kansalliskirjasto.fi/fi/e-kirjasto/e-kirjasto-sovelluksen-kayttoohje")
+    )
+  override val instructionsSV: DocumentConfiguration? =
+    DocumentConfiguration(
+      name = null,
+      remoteURI = URI.create("https://www.kansalliskirjasto.fi/sv/e-biblioteket/anvisningar-e-biblioteket")
+    )
+  override val instructionsEN: DocumentConfiguration? =
+    DocumentConfiguration(
+      name = null,
+      remoteURI = URI.create("https://www.kansalliskirjasto.fi/en/e-library/e-library-instructions")
+    )
+
   override val faq: DocumentConfiguration? =
     DocumentConfiguration(
       name = null,

--- a/simplified-documents/src/main/java/org/librarysimplified/documents/DocumentConfigurationServiceType.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/DocumentConfigurationServiceType.kt
@@ -47,8 +47,25 @@ interface DocumentConfigurationServiceType {
   val licenses: DocumentConfiguration?
 
   /**
-   * @return The application FAQ, if any.
+   * @return The User instructions in finnish, if any.
    */
 
+  val instructionsFI: DocumentConfiguration?
+
+  /**
+   * @return The User instructions in swedish, if any.
+   */
+
+  val instructionsSV: DocumentConfiguration?
+
+  /**
+   * @return The User instructions in english, if any.
+   */
+
+  val instructionsEN: DocumentConfiguration?
+
+  /**
+   * @return The application FAQ, if any.
+   */
   val faq: DocumentConfiguration?
 }

--- a/simplified-documents/src/main/java/org/librarysimplified/documents/DocumentStoreType.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/DocumentStoreType.kt
@@ -48,6 +48,21 @@ interface DocumentStoreType {
   val licenses: DocumentType?
 
   /**
+   * @return The application Instruction in finnish, if any.
+   */
+  val instructionsFI: DocumentType?
+
+  /**
+   * @return The application Instruction in swedish, if any.
+   */
+  val instructionsSV: DocumentType?
+
+  /**
+   * @return The application Instruction in english, if any.
+   */
+  val instructionsEN: DocumentType?
+
+  /**
    * @return The application FAQ, if any.
    */
 

--- a/simplified-documents/src/main/java/org/librarysimplified/documents/internal/DocumentStore.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/internal/DocumentStore.kt
@@ -21,6 +21,9 @@ internal class DocumentStore private constructor(
   override val privacyPolicy: DocumentType?,
   override val feedback: DocumentType?,
   override val accessibilityStatement: DocumentType?,
+  override val instructionsEN: DocumentType?,
+  override val instructionsFI: DocumentType?,
+  override val instructionsSV: DocumentType?,
   override val faq: DocumentType?
 ) : DocumentStoreType {
 
@@ -91,6 +94,27 @@ internal class DocumentStore private constructor(
           config = configuration.accessibilityStatement
         )
 
+      val instructionsFI =
+        this.documentForMaybe(
+          assetManager = assetManager,
+          http = http,
+          baseDirectory = baseDirectory,
+          config = configuration.instructionsFI
+        )
+      val instructionsSV =
+        this.documentForMaybe(
+          assetManager = assetManager,
+          http = http,
+          baseDirectory = baseDirectory,
+          config = configuration.instructionsSV
+        )
+      val instructionsEN =
+        this.documentForMaybe(
+          assetManager = assetManager,
+          http = http,
+          baseDirectory = baseDirectory,
+          config = configuration.instructionsEN
+        )
 
       val faq =
         this.documentForMaybe(
@@ -108,6 +132,9 @@ internal class DocumentStore private constructor(
         privacyPolicy = privacyPolicy,
         feedback = feedback,
         accessibilityStatement = accessibilityStatement,
+        instructionsEN = instructionsEN,
+        instructionsFI = instructionsFI,
+        instructionsSV = instructionsSV,
         faq = faq
       )
     }

--- a/simplified-documents/src/main/java/org/librarysimplified/documents/internal/EmptyDocumentStore.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/internal/EmptyDocumentStore.kt
@@ -22,6 +22,12 @@ internal object EmptyDocumentStore : DocumentStoreType {
     null
   override val licenses: DocumentType? =
     null
+  override val instructionsFI: DocumentType? =
+    null
+  override val instructionsSV: DocumentType? =
+    null
+  override val instructionsEN: DocumentType? =
+    null
   override val faq: DocumentType? =
     null
 

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -73,7 +73,7 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private lateinit var buttonUserAgreement: Button
   private lateinit var buttonAccessibilityStatement: Button
   private lateinit var buttonLicenses: Button
-  private lateinit var buttonFaq: Button
+  private lateinit var buttonInstructions: Button
   private lateinit var versionText: TextView
   private lateinit var bookmarkSyncProgress: ProgressBar
   private lateinit var bookmarkSyncCheck: SwitchCompat
@@ -115,7 +115,7 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.buttonPrivacyPolicy = view.findViewById(R.id.buttonPrivacyPolicy)
     this.buttonUserAgreement = view.findViewById(R.id.buttonUserAgreement)
     this.buttonLicenses = view.findViewById(R.id.buttonLicenses)
-    this.buttonFaq = view.findViewById(R.id.buttonFaq)
+    this.buttonInstructions = view.findViewById(R.id.buttonInstructions)
     this.versionText = view.findViewById(R.id.appVersion)
     this.bookmarkSyncCheck = view.findViewById(R.id.accountSyncBookmarksCheck)
     this.buttonPreferences = view.findViewById(R.id.buttonPreferences)
@@ -254,7 +254,18 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     configureDocViewButton(buttonPrivacyPolicy, this.viewModel.documents.privacyPolicy)
     configureDocViewButton(buttonUserAgreement, this.viewModel.documents.eula)
     configureDocViewButton(buttonLicenses, this.viewModel.documents.licenses)
-    configureDocViewButton(buttonFaq, this.viewModel.documents.faq)
+    //Configure the doc buttons to the correct language version
+    when (LanguageUtil.getUserLanguage(this.requireContext())) {
+      "fi" -> {
+      configureDocViewButton(buttonInstructions, this.viewModel.documents.instructionsFI)
+      }
+      "sv" -> {
+      configureDocViewButton(buttonInstructions, this.viewModel.documents.instructionsSV)
+      }
+      else -> {
+        configureDocViewButton(buttonInstructions, this.viewModel.documents.instructionsEN)
+      }
+    }
 
     /*
      * Configure preferences button to open the preferences fragment

--- a/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
@@ -159,11 +159,11 @@
             app:layout_constraintTop_toBottomOf="@id/accountTop">
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/buttonFaq"
+                android:id="@+id/buttonInstructions"
                 style="@style/Palace.Button.Outlined.Settings.Arrowed"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/account_faq" />
+                android:text="@string/account_instructions" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonFeedback"

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -74,7 +74,7 @@
   <string name="account_eula">User Agreement</string>
   <string name="account_licenses">Software Licenses</string>
   <string name="account_leave_feedback">Leave feedback</string>
-  <string name="account_faq">Frequently Asked Questions</string>
+  <string name="account_instructions">User instructions</string>
   <string name="account_accessibility_statement">Accessibility Statement</string>
   <string name="account_about_app">About App</string>
   <string name="account_sync_bookmarks_statement">Save your reading position and bookmarks to all your other devices</string>


### PR DESCRIPTION
Replaces the faq link in the settings page with user instructions link. Creates three language versions for the link, as nearly the full link is different in the different language versions.

This version still uses old configureDocViewButton function, but it doesn't replace the language "tag" like it still does for the other links, and instead just creates the correct onClick listener.

This should be changed when all the other links are handled similarly to these links.

TODO: Have other links function the same way aswell

Ref: [EKIRJASTO-116](https://jira.it.helsinki.fi/browse/EKIRJASTO-116)

**Does this require updates to old Transifex strings? Have the translators been informed?**
Have informed translators, one new button string.
