### PR TITLE
EKIRJASTO-242 fix current audiobook player

### DIFF
--- a/additional-strings/ThePalaceProject/android-audiobook/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/additional-strings/ThePalaceProject/android-audiobook/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
   <string name="audiobook_part_download_continue">Continue</string>
 
   <string name="audiobook_player_menu_playback_rate_title">Playback rate</string>
-  <string name="audiobook_player_menu_sleep_title">Set your sleep timer</string>
+  <string name="audiobook_player_menu_sleep_title">Sleep timer</string>
   <string name="audiobook_player_menu_add_bookmark_title">Add bookmark</string>
   <string name="audiobook_player_menu_toc_title">Table of contents</string>
   <string name="audiobook_player_menu_toc_title_bookmarks">Bookmarks</string>

--- a/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
@@ -441,6 +441,9 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
     this.menuPlaybackRateText?.text =
       PlayerPlaybackRateAdapter.textOfRate(this.player.playbackRate)
 
+    //Add the translated title
+    this.menuPlaybackRate.title = this.resources.getString(R.string.audiobook_player_menu_playback_rate_title)
+
     /*
      * On API versions older than 23, playback rate changes will have no effect. There is no
      * point showing the menu.
@@ -471,11 +474,15 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
     this.menuSleep.actionView?.contentDescription = this.sleepTimerContentDescriptionSetUp()
 
     this.menuSleepText = this.menuSleep.actionView?.findViewById(R.id.player_menu_sleep_text)
+    //Add the translated title
+    this.menuSleep.title = this.resources.getString(R.string.audiobook_player_menu_sleep_title)
 
     this.menuTOC = this.toolbar.menu.findItem(R.id.player_menu_toc)
     this.menuTOC.setOnMenuItemClickListener { this.onMenuTOCSelected() }
 
     this.menuAddBookmark = this.bottomToolbar.menu.findItem(R.id.player_menu_add_bookmark)
+    //Add the translated title
+    this.menuAddBookmark.title = this.resources.getString(R.string.audiobook_player_menu_add_bookmark_title)
     this.menuAddBookmark.setOnMenuItemClickListener { this.onMenuAddBookmarkSelected() }
     /*
      * Subscribe to player and timer events. We do the subscription here (as late as possible)
@@ -1145,7 +1152,7 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
   }
 
   private fun spineElementText(spineElement: PlayerSpineElementType): String {
-    return spineElement.title ?: this.getString(
+    return spineElement.title ?: this.getString(//
       R.string.audiobook_player_toc_track_n,
       spineElement.index + 1
     )

--- a/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
@@ -1137,16 +1137,21 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
             )).times(currentPlaybackRate.speed)).toInt()
     }
 
+    //Current time is accurate presentation of the time
+    //That current chapter has played
     val currTime = TimeUnit.SECONDS.toMillis(lastStartedPlayerPosition
       .plus(
         (TimeUnit.MILLISECONDS.toSeconds(
           offsetMilliseconds
         ).minus(lastStartedPlayerPosition
         )).times(currentPlaybackRate.speed)).toLong())
+
+    //Remaining book time
+    //How much book is left minus how much of current chapter has passed
     playerRemainingBookTime.text =
       PlayerTimeStrings.hourMinuteTextFromRemainingTime(
         requireContext(),
-        (getCurrentAudiobookRemainingDuration(spineElement) - currTime).div(currentPlaybackRate.speed).toLong()
+        (getCurrentAudiobookRemainingDuration(spineElement) - currTime)
       )
 
     // The visual presentation of how much of the chapter is left

--- a/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
@@ -1152,7 +1152,7 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
   }
 
   private fun spineElementText(spineElement: PlayerSpineElementType): String {
-    return spineElement.title ?: this.getString(//
+    return spineElement.title ?: this.getString(
       R.string.audiobook_player_toc_track_n,
       spineElement.index + 1
     )

--- a/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
@@ -1065,14 +1065,6 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
               offsetMilliseconds
             ).minus(lastStartedPlayerPosition
             )).times(currentPlaybackRate.speed)).toInt()
-      /*
-      log.debug("Last started: {}", lastStartedPlayerPosition)
-      log.debug("Difference of last started and player position: {}", (TimeUnit.MILLISECONDS.toSeconds(
-        offsetMilliseconds
-      ).minus(lastStartedPlayerPosition
-      ).times(currentPlaybackRate.speed)))
-      log.debug("Player position: {}", this.playerPosition.progress.toString())
-       */
     }
 
     val currTime = TimeUnit.SECONDS.toMillis(lastStartedPlayerPosition

--- a/simplified-viewer-audiobook/src/main/res/values/strings-audiobook-module.xml
+++ b/simplified-viewer-audiobook/src/main/res/values/strings-audiobook-module.xml
@@ -10,7 +10,7 @@
   <string name="audiobook_part_download_continue">Continue</string>
 
   <string name="audiobook_player_menu_playback_rate_title">Playback rate</string>
-  <string name="audiobook_player_menu_sleep_title">Set your sleep timer</string>
+  <string name="audiobook_player_menu_sleep_title">Sleep timer</string>
   <string name="audiobook_player_menu_add_bookmark_title">Add bookmark</string>
   <string name="audiobook_player_menu_toc_title">Table of contents</string>
   <string name="audiobook_player_menu_toc_title_bookmarks">Bookmarks</string>


### PR DESCRIPTION
**What's this do?**
This pr attempts to fix the sleep timer and empty space at the end of the audiobook chapters when on greater player speeds. Also attempts to fix bookmarks going to incorrect spots when in faster speeds.
The buttons also get translated texts, that were previously only in English.

When it comes to the sleep timer, when set to end of chapter, the timer wouldn't work. This was because the audiobook would jump to the next chapter at the same time as the pause request came, so the pause got overwritten. This is now fixed by a boolean check, so if the sleep timer is on and we start a new chapter, we pause at the beginning of it. 
Also fixed timer start for the cases we want to not start the sleep timer. It used to always start the end chapter timer that did not work, but now it can also not start a player.

For the empty space at the end of chapter, the problem was that the player doesn't recognize the player speed is faster, and thus the normal length of the chapter is too long. This is now patched up by some computations that tries to keep in time with the shortened file, and keeps the visible seekbar at correct time, and using the seek bar to know when we should manually skip to the next chapter. Same technique that is used to keep the time, is used to have the bookmarks be at correct spots.

NOTE: This doesn't fix the audio book skipping to the next chapter too early when playing in 0.75x speed, as this is still done by the player itself.

**Why are we doing this? (w/ JIRA link if applicable)**
This is done as a temporary solution to the most annoying audioplayer bugs that present themselves to most users. Most of these will have to be reversed when we update the audioplayer module, at some point. But until then, this is done to better the user experience.

[EKIRJASTO-242] https://jira.it.helsinki.fi/browse/EKIRJASTO-242

**How should this be tested? / Do these changes have associated tests?**
When testing, check all buttons and their actions.
Changing speed should make the numbers running on the player run faster.
The seekbar should present accurately where we are in the audio book, and manually jumping to a particular spot should be accurate.
On higher speeds, putting a bookmark to a spot, after letting the player run for a little while, is accurate, and the jump goes to accurate spot. 
"End of file" sleep timer should pause at the beginning of next chapter on all speeds.
There should be no empty space at the end of chapters.
Check that when jumping to next chapter, the player doesn't accidentally jump over a chapter (was problem at some point in the code).
At the end of a book, the player should pause. 

NOTE: Opening books might require you to change readium:liblcp version from 2.1.0 -> 4.1.0 in build.gradle.kts (simplified-app-ekirjasto), as these changes are done in an older branch. Also check that in build_libraries.toml kotlin-toolkit versions are 2.4.1 

**Does this require updates to old Transifex strings? Have the translators been informed?**
Does need some changes to old Strings
- [ ] Informed translators
