### PR TITLE
EKIRJASTO-287 Hide bookmark sync feature in UI

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -26,8 +26,8 @@ import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggingInWaitin
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoginFailed
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountNotLoggedIn
 import org.nypl.simplified.android.ktx.supportActionBar
-import org.nypl.simplified.bookmarks.api.BookmarkSyncEnableResult
-import org.nypl.simplified.bookmarks.api.BookmarkSyncEnableStatus
+//import org.nypl.simplified.bookmarks.api.BookmarkSyncEnableResult
+//import org.nypl.simplified.bookmarks.api.BookmarkSyncEnableStatus
 import org.nypl.simplified.listeners.api.FragmentListenerType
 import org.nypl.simplified.listeners.api.fragmentListeners
 import org.nypl.simplified.profiles.controller.api.ProfileAccountLoginRequest
@@ -67,7 +67,7 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private lateinit var buttonRegisterPasskey: Button
   private lateinit var buttonDependents: Button
   private lateinit var eulaStatement: TextView
-  private lateinit var syncBookmarks: ConstraintLayout
+//private lateinit var syncBookmarks: ConstraintLayout
   private lateinit var buttonFeedback: Button
   private lateinit var buttonPrivacyPolicy: Button
   private lateinit var buttonUserAgreement: Button
@@ -75,8 +75,8 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private lateinit var buttonLicenses: Button
   private lateinit var buttonInstructions: Button
   private lateinit var versionText: TextView
-  private lateinit var bookmarkSyncProgress: ProgressBar
-  private lateinit var bookmarkSyncCheck: SwitchCompat
+//private lateinit var bookmarkSyncProgress: ProgressBar
+//private lateinit var bookmarkSyncCheck: SwitchCompat
   private lateinit var bookmarkStatement: TextView
   private lateinit var buttonPreferences: Button
 
@@ -109,30 +109,34 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.buttonDependents = view.findViewById(R.id.buttonInviteDependents)
     this.eulaStatement = view.findViewById(R.id.eulaStatement)
     this.buttonAccessibilityStatement = view.findViewById(R.id.accessibilityStatement)
-    this.syncBookmarks = view.findViewById(R.id.accountSyncBookmarks)
-    this.bookmarkStatement = view.findViewById(R.id.accountSyncBookmarksStatement)
+//  this.syncBookmarks = view.findViewById(R.id.accountSyncBookmarks)
+//  this.bookmarkStatement = view.findViewById(R.id.accountSyncBookmarksStatement)
     this.buttonFeedback = view.findViewById(R.id.buttonFeedback)
     this.buttonPrivacyPolicy = view.findViewById(R.id.buttonPrivacyPolicy)
     this.buttonUserAgreement = view.findViewById(R.id.buttonUserAgreement)
     this.buttonLicenses = view.findViewById(R.id.buttonLicenses)
     this.buttonInstructions = view.findViewById(R.id.buttonInstructions)
     this.versionText = view.findViewById(R.id.appVersion)
-    this.bookmarkSyncCheck = view.findViewById(R.id.accountSyncBookmarksCheck)
+//  this.bookmarkSyncCheck = view.findViewById(R.id.accountSyncBookmarksCheck)
     this.buttonPreferences = view.findViewById(R.id.buttonPreferences)
 
 
     this.toolbar =
       view.rootView.findViewWithTag(PalaceToolbar.palaceToolbarName)
+/*
     this.bookmarkSyncProgress =
       view.findViewById(R.id.accountSyncProgress)
+*/
 
     this.viewModel.accountLive.observe(this.viewLifecycleOwner) {
       this.reconfigureAccountUI()
     }
 
+/*
     this.viewModel.accountSyncingSwitchStatus.observe(this.viewLifecycleOwner){ status ->
       this.reconfigureBookmarkSyncingSwitch(status)
     }
+*/
 
     this.reconfigureAccountUI()
   }
@@ -157,13 +161,13 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
       onTryRegisterPasskey()
     }
 
-    /*
-     * Configure the bookmark syncing switch to enable/disable syncing permissions.
-     */
+/*
+    //Configure the bookmark syncing switch to enable/disable syncing permissions.
 
     this.bookmarkSyncCheck.setOnCheckedChangeListener { _, isChecked ->
       this.viewModel.enableBookmarkSyncing(isChecked)
     }
+*/
 
     /*
      * Hide the toolbar and back arrow if there is no page to return to (e.g. coming from a deep link).
@@ -294,8 +298,8 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
       buttonLoginPasskey.visibility = VISIBLE
       buttonRegisterPasskey.visibility = GONE
     }
-    this.syncBookmarks.visibility = GONE
-    this.bookmarkStatement.visibility = GONE
+//  this.syncBookmarks.visibility = GONE
+//  this.bookmarkStatement.visibility = GONE
     this.eulaStatement.visibility = VISIBLE
   }
 
@@ -336,7 +340,7 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
       buttonLoginPasskey.visibility = VISIBLE
       buttonRegisterPasskey.visibility = GONE
     }
-    this.syncBookmarks.visibility = GONE
+//  this.syncBookmarks.visibility = GONE
 
   }
 
@@ -348,9 +352,9 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
       buttonLoginPasskey.visibility = GONE
       buttonRegisterPasskey.visibility = VISIBLE
     }
-    this.syncBookmarks.visibility = VISIBLE
-    this.bookmarkStatement.visibility = VISIBLE
-    this.bookmarkSyncProgress.visibility = INVISIBLE
+//  this.syncBookmarks.visibility = VISIBLE
+//  this.bookmarkStatement.visibility = VISIBLE
+//  this.bookmarkSyncProgress.visibility = INVISIBLE
     this.eulaStatement.visibility = GONE
   }
 
@@ -460,16 +464,14 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     return android.os.Build.VERSION.SDK_INT >= 28
   }
 
+  /*
   private fun reconfigureBookmarkSyncingSwitch(status: BookmarkSyncEnableStatus) {
-    /*
-     * Remove the checked-change listener, because setting `isChecked` will trigger the listener.
-     */
+
+    // Remove the checked-change listener, because setting `isChecked` will trigger the listener.
 
     this.bookmarkSyncCheck.setOnCheckedChangeListener(null)
 
-    /*
-     * Otherwise, the switch is doing something that interests us...
-     */
+    //Otherwise, the switch is doing something that interests us...
 
     val account = this.viewModel.account
     return when (status) {
@@ -504,5 +506,6 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
       }
     }
   }
+  */
 
 }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -6,10 +6,10 @@ import android.view.View.GONE
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import android.widget.Button
-import android.widget.ProgressBar
+//import android.widget.ProgressBar
 import android.widget.TextView
-import androidx.appcompat.widget.SwitchCompat
-import androidx.constraintlayout.widget.ConstraintLayout
+//import androidx.appcompat.widget.SwitchCompat
+//import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -67,7 +67,13 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private lateinit var buttonRegisterPasskey: Button
   private lateinit var buttonDependents: Button
   private lateinit var eulaStatement: TextView
-//private lateinit var syncBookmarks: ConstraintLayout
+/*
+  Bookmark syncing is not currently supported in E-kirjasto
+  private lateinit var syncBookmarks: ConstraintLayout
+  private lateinit var bookmarkSyncProgress: ProgressBar
+  private lateinit var bookmarkSyncCheck: SwitchCompat
+  private lateinit var bookmarkStatement: TextView
+*/
   private lateinit var buttonFeedback: Button
   private lateinit var buttonPrivacyPolicy: Button
   private lateinit var buttonUserAgreement: Button
@@ -75,9 +81,6 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private lateinit var buttonLicenses: Button
   private lateinit var buttonInstructions: Button
   private lateinit var versionText: TextView
-//private lateinit var bookmarkSyncProgress: ProgressBar
-//private lateinit var bookmarkSyncCheck: SwitchCompat
-  private lateinit var bookmarkStatement: TextView
   private lateinit var buttonPreferences: Button
 
   //inherited elements
@@ -464,7 +467,9 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     return android.os.Build.VERSION.SDK_INT >= 28
   }
 
-  /*
+/*
+  Bookmark syncing is not currently supported in E-kirjasto
+
   private fun reconfigureBookmarkSyncingSwitch(status: BookmarkSyncEnableStatus) {
 
     // Remove the checked-change listener, because setting `isChecked` will trigger the listener.
@@ -506,6 +511,6 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
       }
     }
   }
-  */
+*/
 
 }

--- a/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
@@ -78,6 +78,7 @@
                 android:text="@string/accountEULAStatement"
                 android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 
+            <!--
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/accountSyncBookmarks"
                 android:layout_width="match_parent"
@@ -85,14 +86,14 @@
                 android:layout_marginTop="32dp"
                 android:background="@color/EkirjastoSettingsBookmarkBackground">
 
-                <!--            <View-->
-                <!--                android:layout_width="0dp"-->
-                <!--                android:layout_height="1dp"-->
-                <!--                android:background="@color/PalaceDividerColor"-->
-                <!--                app:layout_constraintEnd_toEndOf="parent"-->
-                <!--                app:layout_constraintStart_toStartOf="parent"-->
-                <!--                app:layout_constraintTop_toTopOf="parent"-->
-                <!--                app:layout_constraintBottom_toBottomOf="parent"/>-->
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="1dp"
+                    android:background="@color/PalaceDividerColor"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
                 <TextView
                     android:id="@+id/accountSyncBookmarksLabel"
@@ -142,6 +143,7 @@
                 android:layout_height="wrap_content"
                 android:paddingBottom="32dp"
                 android:text="@string/account_sync_bookmarks_statement" />
+        -->
 
         </LinearLayout>
 

--- a/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_ekirjasto.xml
@@ -79,6 +79,8 @@
                 android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 
             <!--
+            Bookmark syncing is not currently supported in E-kirjasto
+
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/accountSyncBookmarks"
                 android:layout_width="match_parent"


### PR DESCRIPTION
**What's this do?**
- The bookmark sync toggle button is hidden on the Settings tab of the E-kirjasto app
   - Previously: the button and feature was shown to all logged in users
   - Now: the button and feature are not shown to users at any point

**Why are we doing this?**
- The bookmark sync feature is currently not available in the app
    - Jira tasks: EKIRJASTO-287 for Android, EKIRJASTO-288 for iOS
    - For now, the feature is hidden and disabled by commenting out the related code

**How should this be tested?**
- Test with device
    1.  open app
    2. navigate to Settings tab
    3. test these two cases: user logged in and user logged out
    4. see that the sync bookmark toggle button is not visible in Settings tab

**Translations**
- Transifex-tranlations not needed this time