### PR TITLE
EKIRJASTO-320 Add confirmation popups to hold and loan revoke

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -539,7 +539,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
 
     when (val status = book.status) {
       is BookStatus.Held -> {
-        this.onBookStatusHeld(status, bookPreviewStatus)
+        this.onBookStatusHeld(status, bookPreviewStatus, book.book)
       }
       is BookStatus.Loaned -> {
         this.onBookStatusLoaned(status, book.book)
@@ -821,7 +821,8 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
 
   private fun onBookStatusHeld(
     bookStatus: BookStatus.Held,
-    bookPreviewStatus: BookPreviewStatus
+    bookPreviewStatus: BookPreviewStatus,
+    book: Book
   ) {
     this.buttons.removeAllViews()
     
@@ -846,7 +847,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
           this.buttons.addView(
             this.buttonCreator.createRevokeHoldButton(
               onClick = {
-                this.viewModel.revokeMaybeAuthenticated()
+                this.revokeHoldPopup(book)
               }
             )
           )
@@ -892,7 +893,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
           this.buttons.addView(
             this.buttonCreator.createRevokeHoldButton(
               onClick = {
-                this.viewModel.revokeMaybeAuthenticated()
+                this.revokeHoldPopup(book)
               }
             )
           )
@@ -970,7 +971,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
       this.buttons.addView(
         this.buttonCreator.createRevokeLoanButton(
           onClick = {
-            this.viewModel.revokeMaybeAuthenticated()
+            this.revokeLoanPopup(book)
           }
         )
       )
@@ -1137,6 +1138,57 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     val dialog: AlertDialog = builder.create()
     dialog.show()
 
+  }
+  /**
+   * Show user a popup requiring user to confirm a loan revoke
+   */
+  private fun revokeLoanPopup(book: Book) {
+    //Mark that a popup is currently shown
+    popUpShown = true
+    logger.debug("Showing loan revoke popup")
+    val builder: AlertDialog.Builder = AlertDialog.Builder(this.requireContext())
+    builder
+      .setTitle(getString(R.string.bookConfirmReturnTitle, book.entry.title))
+      .setMessage(R.string.bookConfirmReturnMessage)
+      .setPositiveButton(R.string.bookConfirmReturnConfirmButton) { dialog, which ->
+        //Set the popup as closed
+        //And start revoke
+        this.viewModel.revokeMaybeAuthenticated()
+        popUpShown = false
+      }
+      .setNeutralButton(R.string.bookConfirmReturnCancelButton) { dialog, which ->
+        //Do nothing, don't revoke the book
+        popUpShown = false
+      }
+
+    val dialog: AlertDialog = builder.create()
+    dialog.show()
+  }
+
+  /**
+   * Show user a popup requiring user to confirm a hold revoke
+   */
+  private fun revokeHoldPopup(book: Book) {
+    //Mark that a popup is currently shown
+    popUpShown = true
+    logger.debug("Showing revoke hold popup")
+    val builder: AlertDialog.Builder = AlertDialog.Builder(this.requireContext())
+    builder
+      .setTitle(getString(R.string.bookConfirmRevokeTitle, book.entry.title))
+      .setMessage(R.string.bookConfirmRevokeMessage)
+      .setPositiveButton(R.string.bookConfirmRevokeConfirmButton) { dialog, which ->
+        //Set the popup as closed
+        //And start revoke
+        this.viewModel.revokeMaybeAuthenticated()
+        popUpShown = false
+      }
+      .setNeutralButton(R.string.bookConfirmReturnCancelButton) { dialog, which ->
+        //Do nothing, don't revoke the book
+        popUpShown = false
+      }
+
+    val dialog: AlertDialog = builder.create()
+    dialog.show()
   }
 
   private fun onBookStatusDownloadWaitingForExternalAuthentication() {

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -361,7 +361,7 @@ class CatalogPagedViewHolder(
       this.idleButtons.addView(
         this.buttonCreator.createRevokeLoanButton(
           onClick = {
-            this.listener.revokeMaybeAuthenticated(book)
+            this.revokeLoanPopup(book)
           }
         )
       )
@@ -455,7 +455,7 @@ class CatalogPagedViewHolder(
       this.idleButtons.addView(
         this.buttonCreator.createRevokeHoldButton(
           onClick = {
-            this.listener.revokeMaybeAuthenticated(book)
+            this.revokeHoldPopup(book)
           }
         )
       )
@@ -483,7 +483,7 @@ class CatalogPagedViewHolder(
       this.idleButtons.addView(
         this.buttonCreator.createRevokeHoldButton(
           onClick = {
-            this.listener.revokeMaybeAuthenticated(book)
+            this.revokeHoldPopup(book)
           }
         )
       )
@@ -542,7 +542,8 @@ class CatalogPagedViewHolder(
       this.idleButtons.addView(
         this.buttonCreator.createRevokeLoanButton(
           onClick = {
-            this.listener.revokeMaybeAuthenticated(book)
+            //Show popup asking to confirm revoking the book
+            this.revokeLoanPopup(book)
           }
         )
       )
@@ -558,6 +559,57 @@ class CatalogPagedViewHolder(
     } else {
       this.idleButtons.addView(this.buttonCreator.createButtonSpace())
     }
+  }
+  /**
+  * Show user a popup requiring user to confirm a loan return
+  */
+  private fun revokeLoanPopup(book: Book) {
+    //Mark that a popup is currently shown
+    popUpShown = true
+    logger.debug("Showing book return popup")
+    val builder: AlertDialog.Builder = AlertDialog.Builder(this.context)
+    builder
+      .setTitle(context.getString(R.string.bookConfirmReturnTitle, book.entry.title))
+      .setMessage(R.string.bookConfirmReturnMessage)
+      .setPositiveButton(R.string.bookConfirmReturnConfirmButton) { dialog, which ->
+        //Set the popup as closed
+        //And start revoke
+        this.listener.revokeMaybeAuthenticated(book)
+        popUpShown = false
+      }
+      .setNeutralButton(R.string.bookConfirmReturnCancelButton) { dialog, which ->
+        //Do nothing, don't revoke the book
+        popUpShown = false
+      }
+
+    val dialog: AlertDialog = builder.create()
+    dialog.show()
+  }
+
+  /**
+   * Show user a popup requiring user to confirm a hold revoke
+   */
+  private fun revokeHoldPopup(book: Book) {
+    //Mark that a popup is currently shown
+    popUpShown = true
+    logger.debug("Showing revoke hold popup")
+    val builder: AlertDialog.Builder = AlertDialog.Builder(this.context)
+    builder
+      .setTitle(context.getString(R.string.bookConfirmRevokeTitle, book.entry.title))
+      .setMessage(R.string.bookConfirmRevokeMessage)
+      .setPositiveButton(R.string.bookConfirmRevokeConfirmButton) { dialog, which ->
+        //Set the popup as closed
+        //And start revoke
+        this.listener.revokeMaybeAuthenticated(book)
+        popUpShown = false
+      }
+      .setNeutralButton(R.string.bookConfirmReturnCancelButton) { dialog, which ->
+        //Do nothing, don't revoke the book
+        popUpShown = false
+      }
+
+    val dialog: AlertDialog = builder.create()
+    dialog.show()
   }
 
   @Suppress("UNUSED_PARAMETER")

--- a/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
@@ -101,4 +101,11 @@
   <string name="bookNotEnoughSpaceTitle">Not enough space!</string>
   <string name="bookNotEnoughSpaceMessage">File is too big to store on device. Current free space on device: %1$s. \nFree at least %2$s of space to download the book.</string>
   <string name="bookNotEnoughSpaceButton">Close</string>
+  <string name="bookConfirmReturnTitle">Return \"%1$s\" ?</string>
+  <string name="bookConfirmReturnMessage">Returning this book removes it from your loans and from your device.</string>
+  <string name="bookConfirmReturnConfirmButton">Return</string>
+  <string name="bookConfirmReturnCancelButton">Cancel</string>
+  <string name="bookConfirmRevokeTitle">Revoke hold for \"%1$s\" ?</string>
+  <string name="bookConfirmRevokeMessage">If you revoke this hold you lose your place in the queue.</string>
+  <string name="bookConfirmRevokeConfirmButton">Revoke</string>
 </resources>


### PR DESCRIPTION
**What's this do?**
This pr adds a popup that is shown to user when they try to revoke a loan or a hold.

**Why are we doing this? (w/ JIRA link if applicable)**
Currently clicking the return button returns the book instantly. We got a user description of someone doing this accidentally, and with long hold queues there should be a check so user doesn't lose their loan or hold in queue if they don't want to. 

[EKIRJASTO-320] https://jira.it.helsinki.fi/browse/EKIRJASTO-320

**How should this be tested? / Do these changes have associated tests?**
Can be tested by
- Returning book from loans and holds, and from single book view
- Both places should have the same popup
- Canceling popup should do nothing
- Pressing the revoke/Return button on popup should start the return process

**Did someone actually run this code to verify it works?**
Tested on emulator and physical device

**Does this require updates to old Transifex strings? Have the translators been informed?**
New strings have been added.

- [x] Informed translators
