### PR TITLE
EKIRJASTO-208 Suggest creating passkey on login

### DIFF
--- a/simplified-main/src/main/java/org/librarysimplified/main/AppCache.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/AppCache.kt
@@ -17,7 +17,7 @@ class AppCache internal constructor(private val sharedPreferences: SharedPrefere
      * SharedPreferences keys
      */
     private const val KEY_SEEN_TUTORIAL = "seen_tutorial"
-
+    private const val KEY_SEEN_TIPS = "seen_tips"
   }
 
   /**
@@ -33,4 +33,19 @@ class AppCache internal constructor(private val sharedPreferences: SharedPrefere
   fun isTutorialSeen(): Boolean {
     return sharedPreferences.getBoolean(KEY_SEEN_TUTORIAL, false)
   }
+
+  /**
+   * Set the tips as dismissed
+   */
+  fun setTipsDismissed(dismissed: Boolean) {
+    sharedPreferences.edit().putBoolean(KEY_SEEN_TIPS, dismissed).apply()
+  }
+
+  /**
+   * Checks if the tips are dismissed
+   */
+  fun isTipsDismissed(): Boolean {
+    return sharedPreferences.getBoolean(KEY_SEEN_TIPS, false)
+  }
+
 }

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
@@ -45,6 +45,7 @@ import org.nypl.simplified.profiles.controller.api.ProfileAccountLoginRequest.OA
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.nypl.simplified.ui.accounts.ekirjasto.TextSizeEvent
+import org.nypl.simplified.ui.announcements.TipsEvent
 import org.nypl.simplified.ui.branding.BrandingSplashServiceType
 import org.slf4j.LoggerFactory
 import java.net.URI
@@ -352,6 +353,10 @@ class MainActivity : AppCompatActivity(R.layout.main_host) {
 
       is MainActivityListenedEvent.TextSizeEvent ->
         this.setFontSize(event.event)
+
+      is MainActivityListenedEvent.TipsEvent -> {
+        this.handleTipsEvent(event.event)
+      }
     }
   }
 
@@ -381,6 +386,19 @@ class MainActivity : AppCompatActivity(R.layout.main_host) {
       TutorialEvent.TutorialCompleted ->
         this.onTutorialFinished()
     }
+  }
+
+  private fun handleTipsEvent(event: TipsEvent) {
+    return when (event) {
+      TipsEvent.DismissTips ->
+        this.dismissTips()
+    }
+  }
+
+  private fun dismissTips() {
+    logger.debug("Dissmiss tips")
+    val appCache = AppCache(this)
+    appCache.setTipsDismissed(true)
   }
 
   private fun onTutorialFinished() {

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivityDefaultViewModelFactory.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivityDefaultViewModelFactory.kt
@@ -8,6 +8,7 @@ import org.librarysimplified.ui.tutorial.TutorialEvent
 import org.nypl.simplified.listeners.api.ListenerRepository
 import org.nypl.simplified.listeners.api.ListenerRepositoryFactory
 import org.nypl.simplified.ui.accounts.ekirjasto.TextSizeEvent
+import org.nypl.simplified.ui.announcements.TipsEvent
 
 class MainActivityDefaultViewModelFactory(fallbackFactory: ViewModelProvider.Factory) :
   ListenerRepositoryFactory<MainActivityListenedEvent, Unit>(fallbackFactory) {
@@ -19,6 +20,7 @@ class MainActivityDefaultViewModelFactory(fallbackFactory: ViewModelProvider.Fac
     repository.registerListener(OnboardingEvent::class, MainActivityListenedEvent::OnboardingEvent)
     repository.registerListener(TutorialEvent::class, MainActivityListenedEvent::TutorialEvent)
     repository.registerListener(TextSizeEvent::class, MainActivityListenedEvent::TextSizeEvent)
+    repository.registerListener(TipsEvent::class, MainActivityListenedEvent::TipsEvent)
     repository.registerListener(MainLoginEvent::class, MainActivityListenedEvent::LoginEvent)
   }
 }

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivityListenedEvent.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivityListenedEvent.kt
@@ -20,6 +20,10 @@ sealed class MainActivityListenedEvent {
     val event: org.nypl.simplified.ui.accounts.ekirjasto.TextSizeEvent
   ) : MainActivityListenedEvent()
 
+  data class TipsEvent (
+    val event: org.nypl.simplified.ui.announcements.TipsEvent
+  ): MainActivityListenedEvent()
+
   data class LoginEvent(
     val event: MainLoginEvent
   ) : MainActivityListenedEvent()

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -43,7 +43,6 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   private val subscriptions: CompositeDisposable =
     CompositeDisposable()
   private val listener: FragmentListenerType<AccountDetailEvent> by fragmentListeners()
-  private val triggerListener: FragmentListenerType<TextSizeEvent> by fragmentListeners()
   private val parameters: AccountFragmentParameters by lazy {
     this.requireArguments()[PARAMETERS_ID] as AccountFragmentParameters
   }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/HelpEvent.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/HelpEvent.kt
@@ -1,6 +1,0 @@
-package org.nypl.simplified.ui.accounts.ekirjasto
-
-sealed class HelpEvent {
-
-  object ShowPasskeyTip: HelpEvent()
-}

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/HelpEvent.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/HelpEvent.kt
@@ -1,0 +1,6 @@
+package org.nypl.simplified.ui.accounts.ekirjasto
+
+sealed class HelpEvent {
+
+  object ShowPasskeyTip: HelpEvent()
+}

--- a/simplified-ui-announcements/build.gradle.kts
+++ b/simplified-ui-announcements/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     implementation(project(":simplified-profiles-controller-api"))
     implementation(project(":simplified-services-api"))
     implementation(project(":simplified-ui-thread-api"))
+    implementation(project(":simplified-ui-listeners-api"))
 
     implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)

--- a/simplified-ui-announcements/src/main/java/org/nypl/simplified/ui/announcements/TipsDialog.kt
+++ b/simplified-ui-announcements/src/main/java/org/nypl/simplified/ui/announcements/TipsDialog.kt
@@ -1,0 +1,51 @@
+package org.nypl.simplified.ui.announcements
+
+import android.os.Bundle
+import android.view.View
+import android.view.WindowManager
+import android.widget.Button
+import android.widget.TextView
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import org.librarysimplified.services.api.Services
+import org.librarysimplified.ui.announcements.R
+import org.nypl.simplified.listeners.api.FragmentListenerType
+import org.nypl.simplified.listeners.api.fragmentListeners
+
+class TipsDialog : DialogFragment(R.layout.tips_dialog) {
+
+  private val listener: FragmentListenerType<TipsEvent> by fragmentListeners()
+
+  private lateinit var title: TextView
+  private lateinit var content: TextView
+  private lateinit var okButton: Button
+  private lateinit var dismissButton: Button
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    this.title = view.findViewById(R.id.tips_title)
+    this.okButton = view.findViewById(R.id.tips_ok)
+    this.dismissButton = view.findViewById(R.id.tips_dismiss)
+    this.content = view.findViewById(R.id.tips_content)
+  }
+
+  override fun onStart() {
+    super.onStart()
+    dialog?.window?.setLayout(
+      WindowManager.LayoutParams.MATCH_PARENT,
+      WindowManager.LayoutParams.WRAP_CONTENT
+    )
+    this.okButton.setOnClickListener {
+      this.dismiss()
+    }
+
+    this.dismissButton.setOnClickListener{
+      listener.post(TipsEvent.DismissTips)
+    }
+  }
+}

--- a/simplified-ui-announcements/src/main/java/org/nypl/simplified/ui/announcements/TipsDialog.kt
+++ b/simplified-ui-announcements/src/main/java/org/nypl/simplified/ui/announcements/TipsDialog.kt
@@ -6,8 +6,6 @@ import android.view.WindowManager
 import android.widget.Button
 import android.widget.TextView
 import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.viewModels
-import org.librarysimplified.services.api.Services
 import org.librarysimplified.ui.announcements.R
 import org.nypl.simplified.listeners.api.FragmentListenerType
 import org.nypl.simplified.listeners.api.fragmentListeners
@@ -41,10 +39,13 @@ class TipsDialog : DialogFragment(R.layout.tips_dialog) {
       WindowManager.LayoutParams.WRAP_CONTENT
     )
     this.okButton.setOnClickListener {
+      //Close dialog
       this.dismiss()
     }
 
-    this.dismissButton.setOnClickListener{
+    this.dismissButton.setOnClickListener {
+      //Close dialog and mark tips to not be shown again
+      this.dismiss()
       listener.post(TipsEvent.DismissTips)
     }
   }

--- a/simplified-ui-announcements/src/main/java/org/nypl/simplified/ui/announcements/TipsEvent.kt
+++ b/simplified-ui-announcements/src/main/java/org/nypl/simplified/ui/announcements/TipsEvent.kt
@@ -1,0 +1,5 @@
+package org.nypl.simplified.ui.announcements
+
+sealed class TipsEvent {
+  object DismissTips : TipsEvent()
+}

--- a/simplified-ui-announcements/src/main/res/layout/tips_dialog.xml
+++ b/simplified-ui-announcements/src/main/res/layout/tips_dialog.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.nypl.simplified.ui.announcements.TipsDialog">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/tips_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:text="@string/tipsTitle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/tips_content"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:textSize="16sp"
+        android:text="@string/tipsMessage"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tips_title" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/tips_ok"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="25dp"
+        android:enabled="true"
+        android:text="@string/tipsOk"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tips_content" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/tips_dismiss"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="25dp"
+        android:enabled="true"
+        android:text="@string/tipsDismiss"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tips_content" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/simplified-ui-announcements/src/main/res/values/strings.xml
+++ b/simplified-ui-announcements/src/main/res/values/strings.xml
@@ -3,4 +3,8 @@
 <resources>
   <string name="announcementTitle">%1$s (%2$d of %3$d)</string>
   <string name="ok">OK</string>
+  <string name="tipsTitle">Tip: Passkey</string>
+  <string name="tipsMessage">To make login in easier, create a passkey on the settings page. \n\nYou must have screen lock in use on your device to create and use passkey.</string>
+  <string name="tipsOk">Remind me later</string>
+  <string name="tipsDismiss">Don\'t show this again</string>
 </resources>


### PR DESCRIPTION
**What's this do?**
This pr adds a tip popup that shows after user logs in, suggesting user to make a passkey for easier login.

**Why are we doing this? (w/ JIRA link if applicable)**
Some users don't know they can make a passkey, or that it would make logging in easier, so add something informing users of that possibility.

[EKIRJASTO-208] https://jira.it.helsinki.fi/browse/EKIRJASTO-208

**How should this be tested? / Do these changes have associated tests?**
Can be tested by logging in onto an account from anywhere on the app. Reminding later should make the popup appear again on next login. If don't show again is pressed, it should not pop up on next login.

**Did someone actually run this code to verify it works?**
Ran on emulator and real device.

**Does this require updates to old Transifex strings? Have the translators been informed?**
New translations added

- [ ] Informed translators
