### PR TITLE
EKIRJASTO-328 Add popup to logout

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/EKirjastoAccountFragment.kt
@@ -8,6 +8,7 @@ import android.view.View.VISIBLE
 import android.widget.Button
 //import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 //import androidx.appcompat.widget.SwitchCompat
 //import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.os.bundleOf
@@ -147,9 +148,9 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
   override fun onStart() {
     super.onStart()
     this.configureToolbar()
-    this.buttonLogout.setOnClickListener(){
+    this.buttonLogout.setOnClickListener {
       this.logger.debug("Logout clicked")
-      this.viewModel.tryLogout()
+      this.confirmLogout()
     }
     this.buttonLoginSuomiFi.setOnClickListener {
       this.logger.debug("Login with Suomi.Fi clicked")
@@ -461,6 +462,26 @@ class EKirjastoAccountFragment : Fragment(R.layout.account_ekirjasto){
     this.viewModel.account.setLoginState(this.viewModel.account.loginState)
 
     this.subscriptions.clear()
+  }
+
+  /**
+   * Show a popup that informs user of logout and asks confirmation.
+   */
+  private fun confirmLogout() {
+    val builder: AlertDialog.Builder = AlertDialog.Builder(this.requireContext())
+    builder
+      .setTitle(R.string.logoutConfirmTitle)
+      .setMessage(R.string.logoutConfirmMessage)
+      .setPositiveButton(R.string.logoutConfirmConfirm) { dialog, which ->
+        //Trigger logout
+        this.viewModel.tryLogout()
+      }
+      .setNeutralButton(R.string.logoutConfirmCancel) { dialog, which ->
+        //do nothing
+      }
+
+    val dialog: AlertDialog = builder.create()
+    dialog.show()
   }
 
   private fun isPasskeySupported(): Boolean {

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -109,5 +109,8 @@
   <string name="emailNotValid">Enter a Valid Email Address.</string>
   <string name="errorFromServer">Something went wrong. Sign out and back in and try again.</string>
   <string name="errorInCreation">Could not finish request. Check internet connection and try again.</string>
-
+  <string name="logoutConfirmTitle">Sign out</string>
+  <string name="logoutConfirmMessage">If you sign out, your downloads and any saved bookmarks will be removed.</string>
+  <string name="logoutConfirmConfirm">Sign out</string>
+  <string name="logoutConfirmCancel">Cancel</string>
 </resources>


### PR DESCRIPTION
**What's this do?**
This pr adds a popup confirmation to logout, informing user of the deletion of downloads and bookmarks on logout, similar to iOS.

**Why are we doing this? (w/ JIRA link if applicable)**
This is so that user doesn't accidentally log out, and now are more informed about what happens on logout.

https://jira.it.helsinki.fi/browse/EKIRJASTO-328

**How should this be tested? / Do these changes have associated tests?**
Tested by logging in and then pressing log out button.
Should show a popup.

**Did someone actually run this code to verify it works?**
Ran on emulator and real device

**Does this require updates to old Transifex strings? Have the translators been informed?**
Has new strings.

- [x] Translators informed
