### PR TITLE
EKIRJASTO-341 Show position in queue in holds, remove time estimate

### DIFF
--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLoanCreate.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLoanCreate.kt
@@ -224,6 +224,7 @@ class BorrowLoanCreate private constructor() : BorrowSubtaskType {
               queuePosition = a.positionOrNull,
               startDate = a.startDateOrNull,
               isRevocable = a.revoke.isSome,
+              copiesTotal = a.copiesOrNull,
               endDate = a.endDateOrNull
             )
           )

--- a/simplified-books-registry-api/src/main/java/org/nypl/simplified/books/book_registry/BookStatus.kt
+++ b/simplified-books-registry-api/src/main/java/org/nypl/simplified/books/book_registry/BookStatus.kt
@@ -72,6 +72,12 @@ sealed class BookStatus {
 
       val startDate: DateTime?,
 
+      /**
+       * @return The number of copies for this book
+       */
+
+      val copiesTotal: Int?,
+
       override val isRevocable: Boolean,
       override val endDate: DateTime?
     ) : Held() {
@@ -480,6 +486,7 @@ sealed class BookStatus {
         queuePosition = this.someOrNull(a.position),
         startDate = this.someOrNull(a.startDate),
         endDate = this.someOrNull(a.endDate),
+        copiesTotal = this.someOrNull(a.copies),
         isRevocable = a.revoke.isSome
       )
     }

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntryParser.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntryParser.java
@@ -802,11 +802,16 @@ public final class OPDSAcquisitionFeedEntryParser implements OPDSAcquisitionFeed
         final OptionType<DateTime> start_date =
           OPDSXML.getAttributeRFC3339Optional(available, "since");
         OptionType<Integer> queue = Option.none();
+        OptionType<Integer> copies = Option.none();
         if (holds_opt.isSome()) {
           final Some<Element> holds_some = (Some<Element>) holds_opt;
           queue = OPDSXML.getAttributeIntegerOptional(holds_some.get(), "position");
         }
-        return OPDSAvailabilityHeld.get(start_date, queue, end_date, revoke);
+        if (copies_opt.isSome()) {
+          final Some<Element> copies_some = (Some<Element>) copies_opt;
+          copies = OPDSXML.getAttributeIntegerOptional(copies_some.get(), "total");
+        }
+          return OPDSAvailabilityHeld.get(start_date, queue, end_date, copies, revoke);
       }
 
       if ("available".equals(status)) {

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAvailabilityHeld.kt
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAvailabilityHeld.kt
@@ -13,6 +13,7 @@ import java.net.URI
 data class OPDSAvailabilityHeld private constructor(
   val startDate: OptionType<DateTime>,
   val position: OptionType<Int>,
+  val copies: OptionType<Int>,
   private val endDate: OptionType<DateTime>,
 
   /**
@@ -35,6 +36,9 @@ data class OPDSAvailabilityHeld private constructor(
   val positionOrNull: Int?
     get() = this.position.getOrNull()
 
+  val copiesOrNull: Int?
+    get() = this.copies.getOrNull()
+
   /**
    * @return The date that the hold will become unavailable
    */
@@ -54,6 +58,8 @@ data class OPDSAvailabilityHeld private constructor(
     val b = StringBuilder(256)
     b.append("[OPDSAvailabilityHeld position=")
     b.append(this.position)
+    b.append(" copies=")
+    b.append(this.copies)
     b.append(" start_date=")
     this.startDate.map { e: DateTime? ->
       b.append(fmt.print(e))
@@ -77,6 +83,7 @@ data class OPDSAvailabilityHeld private constructor(
      * @param startDate The start date (if known)
      * @param position The queue position
      * @param endDate The end date (if known)
+     * @param copies The number of copies for the book
      * @param revoke An optional revocation link for the hold
      * @return A value that states that a book is on hold
      */
@@ -86,12 +93,14 @@ data class OPDSAvailabilityHeld private constructor(
       startDate: OptionType<DateTime>,
       position: OptionType<Int>,
       endDate: OptionType<DateTime>,
+      copies: OptionType<Int>,
       revoke: OptionType<URI>
     ): OPDSAvailabilityHeld {
       return OPDSAvailabilityHeld(
         startDate = startDate,
         position = position,
         endDate = endDate,
+        copies = copies,
         revoke = revoke
       )
     }

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSJSONParser.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSJSONParser.java
@@ -183,9 +183,11 @@ public final class OPDSJSONParser implements OPDSJSONParserType {
           JSONParserUtilities.getIntegerOptional(n, "position");
         final OptionType<DateTime> in_end_date =
           JSONParserUtilities.getTimestampOptional(n, "end_date");
+        final OptionType<Integer> in_copies =
+          JSONParserUtilities.getIntegerOptional(n, "total");
         final OptionType<URI> in_revoke =
           JSONParserUtilities.getURIOptional(n, "revoke");
-        return OPDSAvailabilityHeld.get(in_start_date, in_position, in_end_date, in_revoke);
+        return OPDSAvailabilityHeld.get(in_start_date, in_position, in_end_date, in_copies, in_revoke);
       }
 
       if (node.has("held_ready")) {

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSJSONSerializer.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSJSONSerializer.java
@@ -163,6 +163,10 @@ public final class OPDSJSONSerializer implements OPDSJSONSerializerType {
             oh.put("position", x);
             return Unit.unit();
           });
+          a.getCopies().map(x -> {
+            oh.put("total", x);
+            return Unit.unit();
+          });
           a.getRevoke().map(uri -> {
             oh.put("revoke", uri.toString());
             return Unit.unit();

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/accessibility/AccessibilityServiceTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/accessibility/AccessibilityServiceTest.kt
@@ -261,7 +261,7 @@ class AccessibilityServiceTest {
     this.bookRegistry.update(
       BookWithStatus(
         book = this.book0,
-        status = BookStatus.Held.HeldInQueue(this.book0.id, null, null, false, null)
+        status = BookStatus.Held.HeldInQueue(this.book0.id, null, null, null,false, null)
       )
     )
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/accessibility/AccessibilityServiceTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/accessibility/AccessibilityServiceTest.kt
@@ -261,7 +261,7 @@ class AccessibilityServiceTest {
     this.bookRegistry.update(
       BookWithStatus(
         book = this.book0,
-        status = BookStatus.Held.HeldInQueue(this.book0.id, null, null, null,false, null)
+        status = BookStatus.Held.HeldInQueue(this.book0.id, null, null, null, false, null)
       )
     )
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BookRevokeTaskTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BookRevokeTaskTest.kt
@@ -960,6 +960,7 @@ class BookRevokeTaskTest {
           Option.none(),
           Option.none(),
           Option.none(),
+          Option.none(),
           Option.some(this.server.url("revoke").toUri())
         )
       )
@@ -1090,6 +1091,7 @@ class BookRevokeTaskTest {
         "Title",
         DateTime.now(),
         OPDSAvailabilityHeld.get(
+          Option.none(),
           Option.none(),
           Option.none(),
           Option.none(),

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSFeedEntryParserTest.java
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSFeedEntryParserTest.java
@@ -164,11 +164,12 @@ public final class OPDSFeedEntryParserTest {
     final OptionType<DateTime> expected_start_date = Option.some(
       OPDSDateParsers.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
     final OptionType<Integer> queue_position = Option.none();
+    final OptionType<Integer> copies_total = Option.some(1);
     final OptionType<DateTime> expected_end_date = Option.none();
     final OptionType<URI> expected_revoke =
       Option.some(new URI("http://example.com/revoke"));
     final OPDSAvailabilityHeld expected = OPDSAvailabilityHeld.get(
-      expected_start_date, queue_position, expected_end_date, expected_revoke);
+      expected_start_date, queue_position, expected_end_date, copies_total,expected_revoke);
 
     Assertions.assertEquals(expected, availability);
     Assertions.assertEquals(1, e.getAcquisitions().size());
@@ -196,10 +197,11 @@ public final class OPDSFeedEntryParserTest {
     final OptionType<DateTime> expected_end_date = Option.some(
       OPDSDateParsers.dateTimeParser().parseDateTime("2010-01-01T00:00:00Z"));
     final OptionType<Integer> queue_position = Option.none();
+    final OptionType<Integer> copies_total = Option.some(1);
     final OptionType<URI> expected_revoke =
       Option.some(new URI("http://example.com/revoke"));
     final OPDSAvailabilityHeld expected = OPDSAvailabilityHeld.get(
-      expected_start_date, queue_position, expected_end_date, expected_revoke);
+      expected_start_date, queue_position, expected_end_date, copies_total, expected_revoke);
 
     Assertions.assertEquals(expected, availability);
     Assertions.assertEquals(1, e.getAcquisitions().size());
@@ -225,11 +227,12 @@ public final class OPDSFeedEntryParserTest {
     final OptionType<DateTime> expected_start_date = Option.some(
       OPDSDateParsers.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
     final OptionType<Integer> queue_position = Option.some(3);
+    final OptionType<Integer> copies_total = Option.some(1);
     final OptionType<DateTime> expected_end_date = Option.none();
     final OptionType<URI> expected_revoke =
       Option.some(new URI("http://example.com/revoke"));
     final OPDSAvailabilityHeld expected = OPDSAvailabilityHeld.get(
-      expected_start_date, queue_position, expected_end_date, expected_revoke);
+      expected_start_date, queue_position, expected_end_date,copies_total, expected_revoke);
 
     Assertions.assertEquals(expected, availability);
     Assertions.assertEquals(1, e.getAcquisitions().size());
@@ -257,10 +260,11 @@ public final class OPDSFeedEntryParserTest {
     final OptionType<DateTime> expected_end_date = Option.some(
       OPDSDateParsers.dateTimeParser().parseDateTime("2010-01-01T00:00:00Z"));
     final OptionType<Integer> queue_position = Option.some(3);
+    final OptionType<Integer> copies_total = Option.some(1);
     final OptionType<URI> expected_revoke =
       Option.some(new URI("http://example.com/revoke"));
     final OPDSAvailabilityHeld expected = OPDSAvailabilityHeld.get(
-      expected_start_date, queue_position, expected_end_date, expected_revoke);
+      expected_start_date, queue_position, expected_end_date, copies_total, expected_revoke);
 
     Assertions.assertEquals(expected, availability);
     Assertions.assertEquals(1, e.getAcquisitions().size());

--- a/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
@@ -23,6 +23,7 @@
   <string name="catalogAccounts">Choose another library catalog…</string>
   <string name="catalogBookAvailabilityHeldIndefinite">You have this book on hold.</string>
   <string name="catalogBookAvailabilityHeldQueue">You are at position %1$d in the queue for this book.</string>
+  <string name="catalogBookAvailabilityHeldQueueWithCopies">You are at position %1$d in the queue for %2$d copies of this book.</string>
   <string name="catalogBookAvailabilityHeldTimed">You will be able to borrow this book in %1$s.</string>
   <string name="catalogBookAvailabilityHeldIndefiniteShort">On hold</string>
   <string name="catalogBookAvailabilityHeldQueueShort">At position: %1$d</string>


### PR DESCRIPTION
As the time estimate for when the hold comes available is unreliable, remove it and prefer showing your position in the queue. To match iOS and to show more information to the user, show how many copies are currently in "circulation" aka how many copies of the book we have.

**What's this do?**
As the time estimate for when the hold comes available is unreliable, remove it and prefer showing your position in the queue. To match iOS and to show more information to the user, show how many copies are currently in "circulation" aka how many copies of the book we have.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.it.helsinki.fi/browse/EKIRJASTO-341

**How should this be tested? / Do these changes have associated tests?**
This can be tested by taking a book on hold and going to the page of the book, there you should see the position in the queue as well as how many copies there are.

**Did someone actually run this code to verify it works?**
Ran on emulator.

**Does this require updates to old Transifex strings? Have the translators been informed?**
One new string

- [x] Translators informed