### PR TITLE
EKIRJASTO-225 Enable edge to edge

### DIFF
--- a/simplified-ekirjasto-magazines/src/main/java/fi/kansalliskirjasto/ekirjasto/magazines/MagazinesFragment.kt
+++ b/simplified-ekirjasto-magazines/src/main/java/fi/kansalliskirjasto/ekirjasto/magazines/MagazinesFragment.kt
@@ -17,6 +17,9 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import fi.ekirjasto.magazines.R
@@ -133,6 +136,21 @@ class MagazinesFragment : Fragment(R.layout.magazines) {
     signInPromptLayout = view.findViewById(R.id.magazinesSignInPromptLayout)
     browsingLayout = view.findViewById(R.id.magazinesBrowsingLayout)
     browsingWebView = browsingLayout.findViewById(R.id.magazinesBrowsingWebView)
+
+    //Set insetlistener to ensure overlapping with systembars
+    ViewCompat.setOnApplyWindowInsetsListener(browsingWebView) { view, insets ->
+      val insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+      // Apply the insets as a margin to the view
+      view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+        topMargin = insets.top
+        leftMargin = insets.left
+        rightMargin = insets.right
+      }
+
+      // Return CONSUMED as we don't want the window insets to keep passing
+      // down to descendant views.
+      WindowInsetsCompat.CONSUMED
+    }
     configureBrowsingWebView()
 
     // UI state changes will call reconfigureUI
@@ -169,11 +187,6 @@ class MagazinesFragment : Fragment(R.layout.magazines) {
     window.attributes.windowAnimations = android.R.style.Animation_Dialog
     //val wic = WindowInsetsControllerCompat(window, window.decorView)
     //wic.isAppearanceLightStatusBars = true
-    // Set status bar color
-    window.statusBarColor = ContextCompat.getColor(
-      requireContext(),
-      org.thepalaceproject.theme.core.R.color.PalaceStatusBarColor
-    )
     val paramsWebView = RelativeLayout.LayoutParams(
       RelativeLayout.LayoutParams.MATCH_PARENT,
       ViewGroup.LayoutParams.MATCH_PARENT

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
@@ -105,19 +105,17 @@ class MainActivity : AppCompatActivity(R.layout.main_host) {
     interceptDeepLink()
     val toolbar: Toolbar = this.findViewById(R.id.mainToolbar)
 
+    //Add insets so we don't have overlap with system bars
     ViewCompat.setOnApplyWindowInsetsListener(toolbar) { view, insets ->
       val insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-      // Apply the insets as a margin to the view. This solution sets
-      // only the bottom, left, and right dimensions, but you can apply whichever
-      // insets are appropriate to your layout. You can also update the view padding
-      // if that's more appropriate.
+      // Apply the insets as a margin to the view
       view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
         topMargin = insets.top
         leftMargin = insets.left
         rightMargin = insets.right
       }
 
-      // Return CONSUMED if you don't want the window insets to keep passing
+      // Return CONSUMED since we don't want the window insets to keep passing
       // down to descendant views.
       WindowInsetsCompat.CONSUMED
     }

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
@@ -8,10 +8,15 @@ import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.view.ViewGroup
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
@@ -92,12 +97,30 @@ class MainActivity : AppCompatActivity(R.layout.main_host) {
 
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
     this.logger.debug("onCreate (recreating {})", savedInstanceState != null)
     super.onCreate(savedInstanceState)
     this.logger.debug("onCreate (super completed)")
 
     interceptDeepLink()
     val toolbar: Toolbar = this.findViewById(R.id.mainToolbar)
+
+    ViewCompat.setOnApplyWindowInsetsListener(toolbar) { view, insets ->
+      val insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+      // Apply the insets as a margin to the view. This solution sets
+      // only the bottom, left, and right dimensions, but you can apply whichever
+      // insets are appropriate to your layout. You can also update the view padding
+      // if that's more appropriate.
+      view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+        topMargin = insets.top
+        leftMargin = insets.left
+        rightMargin = insets.right
+      }
+
+      // Return CONSUMED if you don't want the window insets to keep passing
+      // down to descendant views.
+      WindowInsetsCompat.CONSUMED
+    }
     this.setSupportActionBar(toolbar)
     this.supportActionBar?.setDisplayHomeAsUpEnabled(true)
     this.supportActionBar?.setDisplayShowHomeEnabled(true)

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragment.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragment.kt
@@ -100,19 +100,17 @@ class MainFragment : Fragment(R.layout.main_tabbed_host) {
     this.bottomView =
       view.findViewById(R.id.bottomNavigator)
 
+    //Add inset to bottom bar so it is shown correctly
     ViewCompat.setOnApplyWindowInsetsListener(bottomView) {view, insets ->
       val insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-      // Apply the insets as a margin to the view. This solution sets
-      // only the bottom, left, and right dimensions, but you can apply whichever
-      // insets are appropriate to your layout. You can also update the view padding
-      // if that's more appropriate.
+      // Apply the insets as a margin to the view.
       view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
         leftMargin = insets.left
         bottomMargin = insets.bottom
         rightMargin = insets.right
       }
 
-      // Return CONSUMED if you don't want the window insets to keep passing
+      // Return CONSUMED as we don't want the window insets to keep passing
       // down to descendant views.
       WindowInsetsCompat.CONSUMED
     }

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainFragment.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainFragment.kt
@@ -7,8 +7,11 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.forEach
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
@@ -96,6 +99,23 @@ class MainFragment : Fragment(R.layout.main_tabbed_host) {
 
     this.bottomView =
       view.findViewById(R.id.bottomNavigator)
+
+    ViewCompat.setOnApplyWindowInsetsListener(bottomView) {view, insets ->
+      val insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+      // Apply the insets as a margin to the view. This solution sets
+      // only the bottom, left, and right dimensions, but you can apply whichever
+      // insets are appropriate to your layout. You can also update the view padding
+      // if that's more appropriate.
+      view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+        leftMargin = insets.left
+        bottomMargin = insets.bottom
+        rightMargin = insets.right
+      }
+
+      // Return CONSUMED if you don't want the window insets to keep passing
+      // down to descendant views.
+      WindowInsetsCompat.CONSUMED
+    }
 
     /*
      * Hide various tabs based on build configuration and other settings.

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/suomifi/AccountEkirjastoSuomiFiFragment.kt
@@ -4,10 +4,14 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import android.view.View.INVISIBLE
+import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.ProgressBar
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import io.reactivex.disposables.CompositeDisposable
@@ -72,6 +76,23 @@ class AccountEkirjastoSuomiFiFragment : Fragment(R.layout.account_ekirjastosuomi
     super.onViewCreated(view, savedInstanceState)
     this.progress = view.findViewById(R.id.suomifiprogressBar)
     this.webView = view.findViewById(R.id.suomifiWebView)
+
+    //Add insets so we don't have overlap with system bars
+    ViewCompat.setOnApplyWindowInsetsListener(webView) { view, insets ->
+      val insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+      // Apply the insets as a margin to the view
+      view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+        topMargin = insets.top
+        leftMargin = insets.left
+        rightMargin = insets.right
+        bottomMargin = insets.bottom
+      }
+
+      // Return CONSUMED as we don't want the window insets to keep passing
+      // down to descendant views.
+      WindowInsetsCompat.CONSUMED
+    }
+
     WebViewUtilities.setForcedDark(this.webView.settings, resources.configuration)
 
     if (this.viewModel.isWebViewClientReady) {


### PR DESCRIPTION
**What's this do?**
Enable edge-to-edge for the app.
The look of the app doesn't change, but changes have been made to main view, bottom bar, as well as the magazine view and the Suomi.fi login page.
Enabling edge-to-edge makes it so that the application view can be shown under the status bar, as well as the bottom bar buttons (if a phone has those visible), so we had to ensure our application buttons don't overlap with anything.

These do not do changes to how the audio player and book reader look, as they come from libraries.

in this pr there is also a bump for the android platform. To enable edge-to-edge, needed to bump the androidx_activity to a newer version. Google_materials was also updated to remove some deprecated code that doesn't work with edge-to-edge.

Ideas for later: We could make it so that the bottom bar disappears when scrolling to provide user even more space to see books

**Why are we doing this? (w/ JIRA link if applicable)**
This needs to be done as Android 15 uses the edge to edge behavior by default, and we need to ensure our application works with these changes.
Also has backwards compability.

https://jira.it.helsinki.fi/browse/EKIRJASTO-225

**How should this be tested? / Do these changes have associated tests?**
Can be tested by rummaging round the app, and seeing if anything is going under the status bar. Should be tested on devices that both don't, and do have the bottom buttons.
Mainly check main page, Suomi.fi login screen, and magazines.

**Did someone actually run this code to verify it works?**
Ran on emulator and a real device with the bottom buttons to ensure there is no overlap. Also ran on different Android versions to ensure backward compatibility.

**Does this require updates to old Transifex strings? Have the translators been informed?**
No new strings.