### PR TITLE
update translations

### DIFF
--- a/simplified-app-ekirjasto/src/main/assets/txnative/sv/txstrings.json
+++ b/simplified-app-ekirjasto/src/main/assets/txnative/sv/txstrings.json
@@ -775,7 +775,7 @@
          "string" : "Din plats i kön: %1$d"
       },
       "catalogBookAvailabilityHeldQueueWithCopies" : {
-         "string" : "Du är på plats %1$d i kön. Bokoen har %2$d samtidiga läsrättigheter."
+         "string" : "Du är på plats %1$d i kön. Boken har %2$d samtidiga läsrättigheter."
       },
       "catalogBookAvailabilityHeldTimed" : {
          "string" : "Du kommer att kunna låna denna bok om %1$s."


### PR DESCRIPTION
**This pull request includes a minor text correction in the Swedish localization file for the app.**
The change fixes a typo in the string for displaying queue position and concurrent reading rights.

* [`simplified-app-ekirjasto/src/main/assets/txnative/sv/txstrings.json`](diffhunk://#diff-71124e6701ad2ec367172c9681570d970d7e10e5fdbe56087adb6b075b42d5f1L778-R778): Corrected "Bokoen" to "Boken" in the `catalogBookAvailabilityHeldQueueWithCopies` string to fix a typo in the Swedish translation.