### PR TITLE
EKIRJASTO-415 Fix audiobook crash

### DIFF
--- a/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
@@ -1360,8 +1360,13 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
         ).minus(lastStartedPlayerPosition
         ))))
 
-    //How much of book is remaining
-    val bookRemaining = getCurrentAudiobookRemainingDuration(this.playerPositionCurrentSpine!!).minus(currentChapterPassed)
+    //How much of book is remaining, if no current player position, return false
+    var bookRemaining = 0L
+    if (this.playerPositionCurrentSpine != null){
+      bookRemaining = getCurrentAudiobookRemainingDuration(this.playerPositionCurrentSpine!!).minus(currentChapterPassed)
+    } else {
+      return false
+    }
 
     // Return true if the difference is less than 30 seconds,
     // which indicates the need to jump to the beginning of the book


### PR DESCRIPTION
**What's this do?**
This adds a nullcheck to the needsToSkipToBeginning function, so if there is no playerPositionCurrentSpine for some reason, we just return false and assume we don't have to jump to the start of the book, instead of trying to compute whether or not we should skip to the start.

**Why are we doing this? (w/ JIRA link if applicable)**
The playerPositionCurrentSpine being null caused crashing for some users.

https://jira.it.helsinki.fi/browse/EKIRJASTO-415

**How should this be tested? / Do these changes have associated tests?**
Haven't been able to recreate the crash, so no way to test this, other than checking that the jumping back when current book has gone on less than 30 seconds works on a book that has short chapters (that I couldn't find from test collection).

**Did someone actually run this code to verify it works?**
Audiobook player and the function works like it did before on emulator.

**Does this require updates to old Transifex strings? Have the translators been informed?**
No new strings
