### PR TITLE
EKIRJASTO-416 Add null check to refresh request

### DIFF
--- a/simplified-ekirjasto-magazines/src/main/java/fi/kansalliskirjasto/ekirjasto/magazines/MagazinesViewModel.kt
+++ b/simplified-ekirjasto-magazines/src/main/java/fi/kansalliskirjasto/ekirjasto/magazines/MagazinesViewModel.kt
@@ -151,7 +151,14 @@ class MagazinesViewModel(
           logger.debug("Try refreshing accessToken")
           val account = profilesController.profileCurrent().mostRecentAccount()
           val authenticationDescription = account.provider.authentication as AccountProviderAuthenticationDescription.Ekirjasto
-          val credentials = account.loginState.credentials as AccountAuthenticationCredentials.Ekirjasto
+          val credentials = account.loginState.credentials as AccountAuthenticationCredentials.Ekirjasto?
+          //if we are not logged in or are in any other state that comes with null credentials
+          //Mark request as failed and return
+          if (credentials == null) {
+            logger.debug("No credentials, cancel refresh")
+            onTokenResult(null)
+            return
+          }
           val accessToken = credentials.accessToken
 
           //Launch accessToken refresh


### PR DESCRIPTION
**What's this do?**
Added a null check to the credentials, and if there are none, instead of trying to refresh the token, mark the magazines load  as failed, and continue on normally.

**Why are we doing this? (w/ JIRA link if applicable)**
If for some reason, when refresh request returns from the server, and out login is in a state where there are no credentials, (like logged out or login failed or such states) the app would crash due to expected credentials value.

https://jira.it.helsinki.fi/browse/EKIRJASTO-416

**How should this be tested? / Do these changes have associated tests?**
Have not recreated the error, so can not be tested.

**Did someone actually run this code to verify it works?**
Runs normally on emulator.

**Does this require updates to old Transifex strings? Have the translators been informed?**
No new translations.