### PR TITLE
EKIRJASTO-422 Move tutorial close button from under the top bar

### DIFF
--- a/simplified-ui-tutorial/src/main/java/org/librarysimplified/ui/tutorial/TutorialFragment.kt
+++ b/simplified-ui-tutorial/src/main/java/org/librarysimplified/ui/tutorial/TutorialFragment.kt
@@ -5,6 +5,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.LinearLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayout
@@ -64,6 +67,18 @@ class TutorialFragment : Fragment(R.layout.fragment_tutorial) {
     this.screenSizeInformation =
       services.requireService(ScreenSizeInformationType::class.java)
 
+    ViewCompat.setOnApplyWindowInsetsListener(skipButton) { view, insets ->
+      val insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+      // Apply the insets as a margin to the view
+      view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+        topMargin = insets.top
+        leftMargin = insets.left
+        rightMargin = insets.right
+      }
+      // Return CONSUMED as we don't want the window insets to keep passing
+      // down to descendant views.
+      WindowInsetsCompat.CONSUMED
+    }
     setupUI()
   }
 


### PR DESCRIPTION
**What's this do?**
Moves the button to close the tutorial so that it's not hidden under the status bar.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.it.helsinki.fi/browse/EKIRJASTO-422

**How should this be tested? / Do these changes have associated tests?**
Empty the app memory so the tutorial is shown, and check that the button is not under the info that the device shows on top.

**Did someone actually run this code to verify it works?**
Ran on emulator.

**Does this require updates to old Transifex strings? Have the translators been informed?**
No new strings.