### PR TITLE
EKIRJASTO-421 Fix audio description for favorites in catalog

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -163,7 +163,7 @@ class CatalogPagedViewHolder(
         ContextCompat.getDrawable(context,R.drawable.baseline_check_circle_24)
       )
       //Set audio description to the button
-      this.idleSelectedButton.contentDescription = context.getString(R.string.catalogAccessibilityBookSelect)
+      this.idleSelectedButton.contentDescription = context.getString(R.string.catalogAccessibilityBookUnselect)
       this.idleSelectedButton.setOnClickListener{
         //Remove book from selected
         this.listener.unselectBook(item)
@@ -174,7 +174,7 @@ class CatalogPagedViewHolder(
         ContextCompat.getDrawable(context,R.drawable.round_add_circle_outline_24)
       )
       //Add audio description
-      this.idleSelectedButton.contentDescription = context.getString(R.string.catalogAccessibilityBookUnselect)
+      this.idleSelectedButton.contentDescription = context.getString(R.string.catalogAccessibilityBookSelect)
       this.idleSelectedButton.setOnClickListener {
         //Add book to selected
         this.listener.selectBook(item)


### PR DESCRIPTION
**What's this do?**
Switch the audio descriptions between the add to favorites and remove from favorites buttons as they were the wrong way round in catalog, yet correct in one book view.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.it.helsinki.fi/browse/EKIRJASTO-421

**How should this be tested? / Do these changes have associated tests?**
Use a screen reader to check the button texts are the correct way round.

**Did someone actually run this code to verify it works?**
Checked on real device.

**Does this require updates to old Transifex strings? Have the translators been informed?**
No new translations.
