### PR TITLE
EKIRJASTO-433 Add new fields and texts

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -516,12 +516,14 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
       this.metadata.addView(row)
     }
 
+    /* Hide updated info for now, as it does not show what we want it to show
     this.run {
       val (row, rowKey, rowVal) = this.bookInfoViewOf()
       rowKey.text = this.getString(R.string.catalogMetaUpdatedDate)
       rowVal.text = this.dateTimeFormatter.print(entry.updated)
       this.metadata.addView(row)
     }
+     */
 
     val duration = entry.duration
     if (duration.isSome) {
@@ -529,6 +531,48 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
       val (row, rowKey, rowVal) = this.bookInfoViewOf()
       rowKey.text = this.getString(R.string.catalogMetaDuration)
       rowVal.text = formatDuration(durationValue)
+      this.metadata.addView(row)
+    }
+
+    val accessibilityFeatures = null //later entry.accessibilityFeatures
+    if (accessibilityFeatures != null) {
+      val accessibilityFeaturesValue = (accessibilityFeatures as Some<String>).get()
+      val (row, rowKey, rowVal) = this.bookInfoViewOf()
+      rowKey.text = this.getString(R.string.catalogMetaAccessibilityFeatures)
+      rowVal.text = "Value"
+      this.metadata.addView(row)
+    } else {
+      val (row, rowKey, rowVal) = this.bookInfoViewOf()
+      rowKey.text = this.getString(R.string.catalogMetaAccessibilityFeatures)
+      rowVal.text = this.getString(R.string.catalogMetaAccessibilityNotAvailable)
+      this.metadata.addView(row)
+    }
+
+    val accessMode = null //later entry.accessMode
+    if (accessMode != null) {
+      val accessModeValue = (accessMode as Some<String>).get()
+      val (row, rowKey, rowVal) = this.bookInfoViewOf()
+      rowKey.text = this.getString(R.string.catalogMetaAccessMode)
+      rowVal.text = "Value"
+      this.metadata.addView(row)
+    } else {
+      val (row, rowKey, rowVal) = this.bookInfoViewOf()
+      rowKey.text = this.getString(R.string.catalogMetaAccessMode)
+      rowVal.text = this.getString(R.string.catalogMetaAccessibilityNotAvailable)
+      this.metadata.addView(row)
+    }
+
+    val accessibilitySummary = null //later entry.accessibilitySummary
+    if (accessibilitySummary != null) {
+      val accessibilitySummaryValue = (accessibilitySummary as Some<String>).get()
+      val (row, rowKey, rowVal) = this.bookInfoViewOf()
+      rowKey.text = this.getString(R.string.catalogMetaAccessibilitySummary)
+      rowVal.text = "Value"
+      this.metadata.addView(row)
+    } else {
+      val (row, rowKey, rowVal) = this.bookInfoViewOf()
+      rowKey.text = this.getString(R.string.catalogMetaAccessibilitySummary)
+      rowVal.text = this.getString(R.string.catalogMetaAccessibilityNotAvailable)
       this.metadata.addView(row)
     }
   }

--- a/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
@@ -80,6 +80,10 @@
   <string name="catalogMetaTranslators">Translators</string>
   <string name="catalogMetaIllustrators">Illustrators</string>
   <string name="catalogMetaId">ISBN</string>
+  <string name="catalogMetaAccessibilityFeatures">Accessibility features</string>
+  <string name="catalogMetaAccessMode">Access mode</string>
+  <string name="catalogMetaAccessibilitySummary">Accessibility summary</string>
+  <string name="catalogMetaAccessibilityNotAvailable">Not yet available</string>
   <string name="catalogMore">More</string>
   <string name="catalogOperationFailed">The operation could not be completed.</string>
   <string name="catalogRead">Read</string>


### PR DESCRIPTION
**What's this do?**
Adds three new fields into the book metadata table, regarding accessibility. No picking up data from the feed implemented yet, so show a placeholder text "Not yet available" for the fields.

Also hide another field that provides useless information.

**Why are we doing this? (w/ JIRA link if applicable)**
Accessibility data needs to be made available to the user.

**How should this be tested? / Do these changes have associated tests?**
Can be checked by looking at the metadata box in any book.

**Did someone actually run this code to verify it works?**
Tested on emulator.

**Does this require updates to old Transifex strings? Have the translators been informed?**

- [ ] Informed translators