### PR TITLE
EKIRJASTO-397 Up target SDK to 35

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,8 @@ org.gradle.configuration-cache-problems=warn
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.parallel=true
 
-org.thepalaceproject.build.androidSDKCompile=34
-org.thepalaceproject.build.androidSDKTarget=34
+org.thepalaceproject.build.androidSDKCompile=35
+org.thepalaceproject.build.androidSDKTarget=35
 org.thepalaceproject.build.androidSDKMinimum=24
 org.thepalaceproject.build.checkSemanticVersioning=false
 org.thepalaceproject.build.enableKtLint=false

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverBadgePainter.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverBadgePainter.kt
@@ -28,7 +28,7 @@ class BookCoverBadgePainter(
     }
 
     val workingBitmap = Bitmap.createBitmap(source)
-    val result = workingBitmap.copy(source.config, true)
+    val result = workingBitmap.copy(source.config!!, true)
     val canvas = Canvas(result)
 
     val left = source.width - badge.width + badgeOffset.x*badge.offsetSize

--- a/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -6,6 +6,7 @@ import android.graphics.Bitmap
 import android.os.Bundle
 import android.widget.ImageView
 import android.widget.Toast
+import androidx.activity.enableEdgeToEdge
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
@@ -175,6 +176,7 @@ class AudioBookPlayerActivity :
   private var destroying: Boolean = false
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
     this.log.debug("onCreate")
     super.onCreate(null)
 

--- a/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/EkirjaPlayerFragment.kt
@@ -28,6 +28,9 @@ import android.widget.ProgressBar
 import android.widget.SeekBar
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import org.joda.time.Duration
@@ -122,6 +125,7 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
   private lateinit var playerWaiting: TextView
   private lateinit var sleepTimer: PlayerSleepTimerType
   private lateinit var timeStrings: PlayerTimeStrings.SpokenTranslations
+  private lateinit var playerView: View
   private lateinit var toolbar: Toolbar
   private lateinit var bottomToolbar: BottomNavigationView
 
@@ -428,6 +432,8 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
     backbutton.setOnClickListener{
       requireActivity().finish()
     }
+    val backbuttonText:TextView = this.toolbar.findViewById(org.librarysimplified.viewer.audiobook.R.id.backText)
+    backbuttonText.text = this.resources.getString(R.string.audiobook_accessibility_navigation_back)
     this.menuPlaybackRate = this.bottomToolbar.menu.findItem(R.id.player_menu_playback_rate)
 
     /*
@@ -521,6 +527,23 @@ class EkirjaPlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener
   override fun onViewCreated(view: View, state: Bundle?) {
     this.log.debug("onViewCreated")
     super.onViewCreated(view, state)
+
+    this.playerView = view.findViewById(R.id.player_view)
+    //Add insets so we don't have overlap with system bars
+    ViewCompat.setOnApplyWindowInsetsListener(playerView) { view, insets ->
+      val insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+      // Apply the insets as a margin to the view
+      view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+        topMargin = insets.top
+        leftMargin = insets.left
+        rightMargin = insets.right
+        bottomMargin = insets.bottom
+      }
+
+      // Return CONSUMED since we don't want the window insets to keep passing
+      // down to descendant views.
+      WindowInsetsCompat.CONSUMED
+    }
 
     requireActivity().registerReceiver(playerMediaReceiver,
       IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY)

--- a/simplified-viewer-audiobook/src/main/res/layout/ekirjasto_audio_player_view.xml
+++ b/simplified-viewer-audiobook/src/main/res/layout/ekirjasto_audio_player_view.xml
@@ -11,7 +11,7 @@
         android:id="@+id/audioBookToolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="@color/PalaceInvertedBackgroundColor"
+        app:itemTextColor="?android:textColorPrimary"
         android:minHeight="?attr/actionBarSize"
         android:padding="0dp"
         android:layout_marginBottom="5dp"
@@ -30,15 +30,25 @@
                 android:layout_marginEnd="10dp"
                 android:paddingTop="5dp"
                 android:src="@drawable/back"
-                app:tint="@color/colorEkirjastoGreen" />
+                app:tint="@color/PalaceTextColor" />
             <TextView
+                android:id="@+id/backText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textColor="@color/colorEkirjastoText"
+                android:textStyle="bold"
+                android:textSize="18dp"
+                android:layout_gravity="center_vertical"
                 android:text="Back"/>
         </LinearLayout>
     </androidx.appcompat.widget.Toolbar>
-
+    <View
+        android:id="@+id/topDivider"
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        app:layout_constraintTop_toBottomOf="@id/audioBookToolbar"
+        android:backgroundTint="@color/colorEkirjastoGreen"
+        android:background="?android:attr/dividerHorizontal" />
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/simplified-viewer-audiobook/src/main/res/menu/top_toolbar_menu.xml
+++ b/simplified-viewer-audiobook/src/main/res/menu/top_toolbar_menu.xml
@@ -7,7 +7,7 @@
         android:id="@+id/player_menu_toc"
         android:icon="@drawable/toolbar_toc"
         android:title="@string/audiobook_player_menu_toc_title"
-        app:iconTint="@color/PalaceTextInvertedColor"
+        app:iconTint="@color/PalaceTextColor"
         app:showAsAction="always" />
 
 </menu>

--- a/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.Toast
+import androidx.activity.enableEdgeToEdge
 import androidx.annotation.StringRes
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.appcompat.app.AppCompatActivity
@@ -146,6 +147,7 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
     this.logger.debug(
       "loaded {} content protection providers",
       this.contentProtectionProviders.size

--- a/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
@@ -4,12 +4,17 @@ import android.app.Activity
 import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.Toast
 import androidx.annotation.StringRes
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.transifex.txnative.TxNative
@@ -122,6 +127,7 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
 
   private lateinit var account: AccountType
   private lateinit var parameters: Reader2ActivityParameters
+  private lateinit var fragmentHostView: View
   private lateinit var readerFragment: Fragment
   private lateinit var readerModel: SR2ReaderViewModel
   private lateinit var searchFragment: Fragment
@@ -181,6 +187,21 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
       SR2ReaderFragmentFactory(readerParameters)
 
     super.onCreate(savedInstanceState)
+
+    // Find the fragment host view
+    this.fragmentHostView = findViewById(R.id.reader2FragmentHost)
+
+    // Apply window insets to the fragment host view
+    ViewCompat.setOnApplyWindowInsetsListener(fragmentHostView) { view, insets ->
+      val systemBarsInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+      view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+        topMargin = systemBarsInsets.top
+        leftMargin = systemBarsInsets.left
+        rightMargin = systemBarsInsets.right
+        bottomMargin = systemBarsInsets.bottom
+      }
+      WindowInsetsCompat.CONSUMED
+    }
 
     this.readerModel =
       ViewModelProvider(this, SR2ReaderViewModelFactory(readerParameters))

--- a/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
@@ -193,12 +193,12 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
 
     // Apply window insets to the fragment host view
     ViewCompat.setOnApplyWindowInsetsListener(fragmentHostView) { view, insets ->
-      val systemBarsInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+      val insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
       view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-        topMargin = systemBarsInsets.top
-        leftMargin = systemBarsInsets.left
-        rightMargin = systemBarsInsets.right
-        bottomMargin = systemBarsInsets.bottom
+        topMargin = insets.top
+        leftMargin = insets.left
+        rightMargin = insets.right
+        bottomMargin = insets.bottom
       }
       WindowInsetsCompat.CONSUMED
     }

--- a/simplified-viewer-pdf-pdfjs/src/main/java/org/librarysimplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
+++ b/simplified-viewer-pdf-pdfjs/src/main/java/org/librarysimplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
@@ -7,11 +7,15 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.widget.FrameLayout
 import android.widget.ProgressBar
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.common.util.concurrent.MoreExecutors
 import kotlinx.coroutines.Dispatchers
@@ -75,6 +79,7 @@ class PdfReaderActivity : AppCompatActivity() {
     services.requireService(ProfilesControllerType::class.java)
 
   private lateinit var uiThread: UIThreadServiceType
+  private lateinit var pdfReaderHostView: View
   private lateinit var pdfReaderContainer: FrameLayout
   private lateinit var accountId: AccountID
   private lateinit var bookID: BookID
@@ -93,6 +98,21 @@ class PdfReaderActivity : AppCompatActivity() {
 
     setContentView(R.layout.pdfjs_reader)
     createToolbar(params.documentTitle)
+
+    // Get the reader host
+    this.pdfReaderHostView = findViewById(R.id.pdf_reader)
+
+    // Apply window insets to the reader host
+    ViewCompat.setOnApplyWindowInsetsListener(pdfReaderHostView) { view, insets ->
+      val insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+      view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+        topMargin = insets.top
+        leftMargin = insets.left
+        rightMargin = insets.right
+        bottomMargin = insets.bottom
+      }
+      WindowInsetsCompat.CONSUMED
+    }
 
     this.loadingBar = findViewById(R.id.pdf_loading_progress)
     this.accountId = params.accountId

--- a/simplified-viewer-pdf-pdfjs/src/main/java/org/librarysimplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
+++ b/simplified-viewer-pdf-pdfjs/src/main/java/org/librarysimplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
@@ -12,6 +12,7 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.widget.FrameLayout
 import android.widget.ProgressBar
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -92,6 +93,7 @@ class PdfReaderActivity : AppCompatActivity() {
   private var documentPageIndex: Int = 0
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
     super.onCreate(savedInstanceState)
 
     val params = intent?.getSerializableExtra(PARAMS_ID) as PdfReaderParameters

--- a/simplified-viewer-pdf-pdfjs/src/main/res/layout/pdfjs_reader.xml
+++ b/simplified-viewer-pdf-pdfjs/src/main/res/layout/pdfjs_reader.xml
@@ -2,6 +2,7 @@
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/pdf_reader"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 


### PR DESCRIPTION
**What's this do?**
Bump android SDK target version 34 -> 35. Also adjust views to handle the edge to edge changes. 

Adjust audiobook player view:
- Change the color of the toolbar from black to white and adjust the button colors
Adjust pdf and ebook readers:
- Add insets for both views

**Why are we doing this? (w/ JIRA link if applicable)**
Google demands for upping the SDK version

https://jira.it.helsinki.fi/browse/EKIRJASTO-397

**How should this be tested? / Do these changes have associated tests?**
Can be tested by looking at all views, specially audiobook/ebook/pdf reader views, and ensuring that nothing goes under the status/bottom bars.

Should be tested on emulator versions 35 and some lower version.

**Did someone actually run this code to verify it works?**
Tested on emulators and real device, with emulator SDK versions 33 and 35.

**Does this require updates to old Transifex strings? Have the translators been informed?**
No strings to translate.
