### PR TITLE
EKIRJASTO-302 Stop audiobook duplication

### DIFF
--- a/simplified-app-ekirjasto/src/main/AndroidManifest.xml
+++ b/simplified-app-ekirjasto/src/main/AndroidManifest.xml
@@ -96,6 +96,7 @@
       android:screenOrientation="fullUser"
       android:exported="false"
       android:configChanges="orientation|screenSize"
+      android:launchMode="singleTop"
       android:theme="@style/PalaceTheme.WithoutActionBar" />
 
 <!--    <activity-->


### PR DESCRIPTION
**What's this do?**
Makes it so, that in stead of opening a new activity when the player is clicked in the notification tray, it opens the already existing one, thus stopping duplication of the player.

**Why are we doing this? (w/ JIRA link if applicable)**
[EKIRJASTO-322](https://jira.it.helsinki.fi/browse/EKIRJASTO-322)

**How should this be tested? / Do these changes have associated tests?**
Can be tested by opening an audiobook and putting the app onto the background. Then, when clicking the audio player in the notification tray, it should open to the player, instead of creating another instance of the activity. Just to ensure there is only one player, click the back button on the top left, and the audiobook will close, and there should not be another one under it.

**Did someone actually run this code to verify it works?**
Ran on emulator and read device.

**Does this require updates to old Transifex strings? Have the translators been informed?**
No new translations.