### PR TITLE
EKIRJASTO-302 Inform user more about successful passkey creation and cancel

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/passkey/AccountEkirjastoPasskeyFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/passkey/AccountEkirjastoPasskeyFragment.kt
@@ -3,6 +3,7 @@ package org.nypl.simplified.ui.accounts.ekirjasto.passkey
 import android.os.Bundle
 import android.view.View
 import android.widget.ProgressBar
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import androidx.credentials.CredentialManager
@@ -119,6 +120,17 @@ class AccountEkirjastoPasskeyFragment : Fragment(R.layout.account_ekirjastopassk
   }
 
   private fun postPasskeyFailed(result: TaskResult.Failure<PasskeyAuth>) {
+    //If error in registering, handle special case of it being user cancelled
+    if (this.viewModel.isRegistering){
+      //Check if request was cancelled by the user
+      //If yes, don't show error message, and just toast informing of cancel
+      if (result.steps.last().message == "User cancelled request") {
+        Toast.makeText(this.requireContext(), R.string.errorPasskeyRegisterCancelled, Toast.LENGTH_SHORT).show()
+        //Post to return back to settings view
+        this.listener.post(AccountEkirjastoSuomiFiEvent.Cancel)
+        return
+      }
+    }
     val msg = if(this.viewModel.isRegistering) {R.string.errorPasskeyRegisterFailed} else {R.string.errorPasskeyLoginFailed}
     val newDialog =
       MaterialAlertDialogBuilder(this.requireActivity())

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/passkey/AccountEkirjastoPasskeyFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/ekirjasto/passkey/AccountEkirjastoPasskeyFragment.kt
@@ -91,6 +91,8 @@ class AccountEkirjastoPasskeyFragment : Fragment(R.layout.account_ekirjastopassk
     viewModel.passkeyResult.observe(viewLifecycleOwner){
       when (it) {
         is TaskResult.Success<PasskeyAuth> -> if (this.viewModel.isRegistering){
+          //Make a toast and inform user that passkey creation was successful
+          Toast.makeText(this.requireContext(), R.string.passkeyRegisterSuccessful, Toast.LENGTH_SHORT).show()
           listener.post(AccountEkirjastoSuomiFiEvent.PasskeySuccessful)
         } else {
           postPasskeySuccessful(it.result)

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
   <string name="errorLoginFailed">Could not sign in</string>
   <string name="errorPasskeyLoginFailed">Could not sign in with Passkey</string>
   <string name="errorPasskeyRegisterFailed">Error registering a Passkey</string>
+  <string name="errorPasskeyRegisterCancelled">Passkey creation cancelled</string>
   <string name="errorSuomiFiLoginFailed">Could not sign in with Suomi.fi</string>
   <string name="invite_a_dependent">Invite a Dependent</string>
   <string name="get_dependents">Get Dependents or Children</string>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -96,7 +96,8 @@
   <string name="errorLoginFailed">Could not sign in</string>
   <string name="errorPasskeyLoginFailed">Could not sign in with Passkey</string>
   <string name="errorPasskeyRegisterFailed">Error registering a Passkey</string>
-  <string name="errorPasskeyRegisterCancelled">Passkey creation cancelled</string>
+  <string name="errorPasskeyRegisterCancelled">Passkey registering cancelled</string>
+  <string name="passkeyRegisterSuccessful">Passkey registered successfully</string>
   <string name="errorSuomiFiLoginFailed">Could not sign in with Suomi.fi</string>
   <string name="invite_a_dependent">Invite a Dependent</string>
   <string name="get_dependents">Get Dependents or Children</string>


### PR DESCRIPTION
**What's this do?**
This pr adds toasts for both successful passkey registration, as well as to canceling the passkey creation.
Cancelling passkey creation doesn't now show error page anymore, instead we show a toast and return cleanly to the previous view.

**Why are we doing this? (w/ JIRA link if applicable)**
The passkey creation is vague and has caused some users to create multiple passkeys since they don't know if the creation was correct or not. Also, cancelling the creation was treated same as an actual error, which it shouldn't be.

**Did someone actually run this code to verify it works?**
Tested on real device (Since passkey creation needs to be available)

**Does this require updates to old Transifex strings? Have the translators been informed?**

- [ ] Translators have been informed