### PR TITLE
Add edge-to-edge support to BookPreviewActivity and ErrorPageBaseActivity

### DIFF
--- a/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageBaseActivity.kt
+++ b/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageBaseActivity.kt
@@ -1,7 +1,11 @@
 package org.nypl.simplified.ui.errorpage
 
 import android.os.Bundle
+import android.view.View
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import org.librarysimplified.ui.errorpage.R
 
 /**
@@ -19,7 +23,15 @@ abstract class ErrorPageBaseActivity : AppCompatActivity(R.layout.error_host) {
   private lateinit var errorFragment: ErrorPageFragment
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
     super.onCreate(savedInstanceState)
+
+    val root = findViewById<View>(R.id.errorRoot)
+    ViewCompat.setOnApplyWindowInsetsListener(root) { view, insets ->
+      val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+      view.setPadding(bars.left, bars.top, bars.right, bars.bottom)
+      WindowInsetsCompat.CONSUMED
+    }
 
     val currentIntent =
       this.intent

--- a/simplified-ui-errorpage/src/main/res/layout/error_host.xml
+++ b/simplified-ui-errorpage/src/main/res/layout/error_host.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/errorRoot"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical">

--- a/simplified-viewer-preview/src/main/java/org/librarysimplified/viewer/preview/BookPreviewActivity.kt
+++ b/simplified-viewer-preview/src/main/java/org/librarysimplified/viewer/preview/BookPreviewActivity.kt
@@ -3,13 +3,18 @@ package org.librarysimplified.viewer.preview
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ProgressBar
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.ViewModelProvider
 import com.transifex.txnative.TxNative
 import io.reactivex.disposables.Disposable
@@ -90,10 +95,22 @@ class BookPreviewActivity : AppCompatActivity(R.layout.activity_book_preview) {
   private var viewSubscription: Disposable? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
     super.onCreate(savedInstanceState)
 
     loadingProgress = findViewById(R.id.loading_progress)
     previewContainer = findViewById(R.id.preview_container)
+
+    ViewCompat.setOnApplyWindowInsetsListener(previewContainer) { view, insets ->
+      val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+      view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+        topMargin = bars.top
+        leftMargin = bars.left
+        rightMargin = bars.right
+        bottomMargin = bars.bottom
+      }
+      WindowInsetsCompat.CONSUMED
+    }
 
     this.feedEntry = intent.getSerializableExtra(EXTRA_ENTRY) as FeedEntry.FeedEntryOPDS
 


### PR DESCRIPTION
**What's this do?**

Adds edge-to-edge system-bar handling to two activities that were missing it: _BookPreviewActivity_ and _ErrorPageBaseActivity_. Both now call _androidx.activity.enableEdgeToEdge()_ and install a _WindowInsetsCompat_ listener on their content root so that system-bar insets translate into correct margin (BookPreviewActivity, matching the existing Reader2Activity pattern) or padding (ErrorPageBaseActivity). A new _android:id="@+id/errorRoot"_ was added to _error_host.xml_ to allow the inset listener to target the root view.

**Why are we doing this? (w/ JIRA link if applicable)**

Android 15 enforces edge-to-edge for apps targeting SDK 35. The app already calls enableEdgeToEdge() in its primary activities (MainActivity, Reader2Activity, PdfReaderActivity, AudioBookPlayerActivity), but BookPreviewActivity and ErrorPageBaseActivity were missed. Without the call, they still get drawn edge-to-edge by the OS, but miss the AndroidX helper's automatic system-bar contrast scrim and light/dark handling, and their content can be clipped behind system bars (status bar at top, gesture/nav bar at bottom).

**How should this be tested? / Do these changes have associated tests?**

No automated tests — change is a UI-layer behavior addition.

Manual verification:

1. Android 15 (API 35) emulator or device, gesture nav: Trigger an error page (e.g., try to borrow a book when at the loan limit) — verify the error screen content is fully visible and action buttons reachable.

2. Android 14 (API 34) emulator or device: Same error-page flow. Edge-to-edge is not enforced here, so the screen should look visually identical to pre-branch main. The status bar should retain the light-green PalaceStatusBarColor from the existing themes (no regression for older-Android users).

Both test paths verified before submitting this PR.

**Note:** BookPreviewActivity is also updated in this PR for consistency and futureproofing, but it is currently unreachable from the UI (the preview button is deliberately disabled in CatalogBookDetailFragment via val createPreviewButton = false). The code-level fix is in place, but was not runtime-tested because the activity is not reachable in the shipping app. If the preview feature is ever re-enabled, the edge-to-edge behavior will work correctly without further changes.

**Dependencies for merging? Releasing to production?**

None. No dependency bumps, no build-system changes, no submodule pointer changes. Three files touched, 30 lines added. Orthogonal to (and independent of) the parallel 16KB page-size compliance work — can merge and ship separately.

**Note:** the deprecated _android:statusBarColor_ and _android:navigationBarColor_ attributes in existing themes were intentionally left in place. On Android 15+ they're ignored by the OS; on Android 14 and earlier
  (still a meaningful user base given minSdk=24) they still define the bar colors. Removing them would regress the look on older devices.

**Have you updated the changelog?**

No

**Has the application documentation been updated for these changes?**

Not applicable — internal UI-layer change, no public API or user-facing behavior documentation needed.

**Did someone actually run this code to verify it works?**

Yes — full UI sweep on API 35 emulator (all main flows), plus targeted API 34 verification of the error page and status-bar color preservation.

**Does this require updates to old Transifex strings? Have the translators been informed?**

No — no string changes, no Transifex impact.

**AI was used during the process and I have described above how.**

- [x] AI was used to diagnose the issues and propose edits, which were reviewed, applied, and tested on simulator by human before committing anything.
