### PR TITLE
Limit "book returned" accessibility announcement to user-initiated returns

### DIFF
--- a/simplified-accessibility/src/main/java/org/nypl/simplified/accessibility/AccessibilityService.kt
+++ b/simplified-accessibility/src/main/java/org/nypl/simplified/accessibility/AccessibilityService.kt
@@ -84,11 +84,17 @@ class AccessibilityService private constructor(
         // Nothing to do
       }
       is BookStatus.Loanable -> {
-        val notHoldable = this.previousStatusIsNot(event, BookStatus.Holdable::class.java)
-        val notLoanable = this.previousStatusIsNot(event, BookStatus.Loanable::class.java)
-        val notUnselected = this.previousStatusIsNot(event, BookStatus.Unselected::class.java)
-        val notSelected = this.previousStatusIsNot(event, BookStatus.Selected::class.java)
-        if (notHoldable && notLoanable && notUnselected && notSelected) {
+        // Only announce "returned" when the transition was triggered by a user-initiated
+        // return (Loaned -> Loanable, possibly via RequestingRevoke). Background catalog
+        // syncs that flip a book to Loanable for any other reason (first observation,
+        // server-side state correction, etc.) must not speak — otherwise users hear a
+        // spurious "successfully returned" right after unrelated actions like a failed
+        // borrow on a different book.
+        val previous = event.statusPrevious
+        val cameFromUserReturn =
+          previous is BookStatus.Loaned ||
+            previous is BookStatus.RequestingRevoke
+        if (cameFromUserReturn) {
           this.speak(this.strings.bookReturned(book.entry.title))
         } else {
           // Nothing to do


### PR DESCRIPTION
**What's this do?**

Narrows the condition under which the accessibility service announces "The book '…' has been successfully returned". Previously, the announcement fired for *any* transition into `BookStatus.Loanable` outside a small allowlist (`Holdable`, `Loanable`, `Unselected`, `Selected`). With this change, it only fires when the previous status was `BookStatus.Loaned.*` or `BookStatus.RequestingRevoke` — i.e. a genuine user-initiated return.

Single file touched: `simplified-accessibility/.../AccessibilityService.kt` (+11, -5).

**Why are we doing this? (w/ JIRA link if applicable)**

The previous logic over-fired. A background catalog sync that flipped an unrelated book from `Loaned` (or `null`) into `Loanable` for any non-user reason triggered the "returned" announcement. In practice this fired ~18 ms after a failed borrow on a different book, because the background sync that touches that other book's status races with the failure event. TalkBack users heard "successfully returned" as confirmation of the failed action — a misleading and accessibility-regressing behaviour.

Pre-existing issue, not a regression from recent work. Surfaced during the accessibility review accompanying the 16KB / edge-to-edge modernization.

No JIRA ticket.

**How should this be tested? / Do these changes have associated tests?**

Existing unit test `AccessibilityServiceTest.testBookReturn` (covers `RequestingRevoke → Loanable`) still passes — the user-initiated return path is preserved.

Manual verification with TalkBack enabled:

1. Enable TalkBack on the device/emulator.
2. Open the app while a book is loaned in the background.
3. Attempt a borrow on a *different* book that will fail (e.g. one at the loan limit, or by pulling the network at the wrong moment).
4. During and after the failure, listen: pre-fix you'd hear "The book '…' has been successfully returned" referring to an unrelated synced book. Post-fix, that announcement no longer fires from background sync.
5. Sanity check the regular path: actively return a loaned book → TalkBack still announces "successfully returned".

**Dependencies for merging? Releasing to production?**

None. Single-file change in a leaf module. No dependency bumps, no build-system changes, no submodule pointer changes. Independent of any other open work.

**Have you updated the changelog?**

No

**Has the application documentation been updated for these changes?**

Not applicable — internal accessibility-layer fix, no public API or user-facing documentation impact.

**Did someone actually run this code to verify it works?**

Yes, partly. Manual TalkBack verification was performed on simulator: triggering the previously-problematic scenario (failed borrow with background sync of unrelated books) no longer produced the spurious "successfully returned" announcement. Testing was not exhaustive — further verification welcome during review.

**Does this require updates to old Transifex strings? Have the translators been informed?**

No — no string changes (the `bookReturned` string itself is unchanged; only its trigger condition was narrowed).

**AI was used during the process and I have described above how.**

- [x] AI was used to diagnose the issue and propose the edit, which was reviewed, applied, compile-checked, unit-tested locally, and manually verified on simulator with TalkBack before committing.