### PR TITLE
EKIRJASTO-767 Add handling of unavailable books being returned to the server

### DIFF
--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookRevokeTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookRevokeTask.kt
@@ -279,7 +279,7 @@ class BookRevokeTask(
     } else {
       // new entry is null, so the book has been removed from the collection, so just copy the old
       // book we have in database, and change the availability to "unavailable"
-      val emptyAvailability = OPDSAvailabilityHoldable.get(Option.of(0),,Option.of(0), Option.of(0))
+      val emptyAvailability = OPDSAvailabilityHoldable.get(Option.of(0),Option.of(0), Option.of(0))
       val entryWithEmptyAvailability = feedEntryWithAvailability(accountID, feedEntry, emptyAvailability)
       this.revokeNotifyServerSaveNewEntry(entryWithEmptyAvailability)
       this.onNewBookEntry(entryWithEmptyAvailability)

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookRevokeTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookRevokeTask.kt
@@ -1,6 +1,6 @@
 package org.nypl.simplified.books.controller
 
-import com.io7m.jfunctional.None
+import com.io7m.jfunctional.Option
 import com.io7m.jfunctional.OptionType
 import com.io7m.jfunctional.Some
 import com.io7m.junreachable.UnreachableCodeException
@@ -273,9 +273,17 @@ class BookRevokeTask(
       else ->
         throw UnreachableCodeException()
     }
-
-    this.revokeNotifyServerSaveNewEntry(newEntry)
-    this.onNewBookEntry(newEntry)
+    if(newEntry != null) {
+      this.revokeNotifyServerSaveNewEntry(newEntry)
+      this.onNewBookEntry(newEntry)
+    } else {
+      // new entry is null, so the book has been removed from the collection, so just copy the old
+      // book we have in database, and change the availability to "unavailable"
+      val emptyAvailability = OPDSAvailabilityHoldable.get(Option.of(0),,Option.of(0), Option.of(0))
+      val entryWithEmptyAvailability = feedEntryWithAvailability(accountID, feedEntry, emptyAvailability)
+      this.revokeNotifyServerSaveNewEntry(entryWithEmptyAvailability)
+      this.onNewBookEntry(entryWithEmptyAvailability)
+    }
   }
 
   private fun feedEntryWithAvailability(
@@ -295,17 +303,24 @@ class BookRevokeTask(
     targetURI: URI,
     revokeType: RevokeType,
     account: AccountType
-  ): FeedEntryOPDS {
+  ): FeedEntryOPDS? {
     this.debug("notifying server of {} revocation via {}", revokeType, targetURI)
     this.taskRecorder.beginNewStep(this.revokeStrings.revokeServerNotifyURI(targetURI))
     this.publishRequestingRevokeStatus()
 
     val feed =
       this.revokeNotifyServerURIFeed(targetURI, account)
-    val entry =
-      this.revokeNotifyServerURIProcessFeed(feed)
 
-    return entry
+    if (feed != null){
+      val entry =
+        this.revokeNotifyServerURIProcessFeed(feed)
+
+      return entry
+    }
+    else {
+      //There was 404 error and the book should just be removed so return null
+      return null
+    }
   }
 
   private fun revokeNotifyServerSaveNewEntry(entry: FeedEntryOPDS) {
@@ -335,7 +350,7 @@ class BookRevokeTask(
    * XXX: Use [FeedLoading.loadSingleEntryFeed]
    */
 
-  private fun revokeNotifyServerURIFeed(targetURI: URI, account: AccountType): Feed {
+  private fun revokeNotifyServerURIFeed(targetURI: URI, account: AccountType): Feed? {
     val credentials = this.getCredentialsFromAccount(account)
 
     /*
@@ -374,6 +389,12 @@ class BookRevokeTask(
       }
 
       is FeedLoaderFailedGeneral -> {
+        if(feedResult.problemReport?.status == 404) {
+          //This just means that there is no loan anymore for the book, so fetch the basic version of the book,
+          //and call it a success
+          logger.debug("404, no loan for the book, should be success")
+          return null
+        }
         val message = this.revokeStrings.revokeServerNotifyFeedFailed
         this.taskRecorder.addAttributesIfPresent(feedResult.problemReport?.toMap())
         this.taskRecorder.currentStepFailed(message, "feedLoaderFailed", feedResult.exception)

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookSyncTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookSyncTask.kt
@@ -1,6 +1,7 @@
 package org.nypl.simplified.books.controller
 
 import com.io7m.jfunctional.None
+import com.io7m.jfunctional.Option
 import com.io7m.jfunctional.Some
 import org.librarysimplified.http.api.LSHTTPClientType
 import org.librarysimplified.http.api.LSHTTPResponseStatus
@@ -26,6 +27,8 @@ import org.nypl.simplified.books.controller.api.BooksControllerType
 import org.nypl.simplified.feeds.api.FeedLoaderType
 import org.nypl.simplified.feeds.api.FeedLoading
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
+import org.nypl.simplified.opds.core.OPDSAvailabilityHoldable
+import org.nypl.simplified.opds.core.OPDSAvailabilityLoanable
 import org.nypl.simplified.opds.core.OPDSAvailabilityRevoked
 import org.nypl.simplified.opds.core.OPDSFeedParserType
 import org.nypl.simplified.opds.core.OPDSParseException
@@ -518,12 +521,32 @@ class BookSyncTask(
        * book registry.
        */
 
-      dbEntry.writeOPDSEntry(entry.feedEntry)
-      val newBook = dbEntry.book.copy(formats = emptyList())
-      val status = BookStatus.fromBook(newBook)
+      // If we weren't able to get a new entry from the server, replace the value with
+      // the one we already have in the registry but set the availability as unavailable
+      if (entry == null) {
+        val oldEntry = dbEntry.book.entry
+        val emptyAvailability = OPDSAvailabilityHoldable.get( Option.of(0),Option.of(0), Option.of(0))
+        val emptyAcquisitionFeedEntry =
+          OPDSAcquisitionFeedEntry.newBuilderFrom(oldEntry)
+            .setAvailability(emptyAvailability)
+            .build()
 
-      this.logger.debug("book's new state is {}", status)
-      this.bookRegistry.update(BookWithStatus(newBook, status))
+        dbEntry.writeOPDSEntry(emptyAcquisitionFeedEntry)
+
+        val newBook = dbEntry.book.copy(formats = emptyList())
+        val status = BookStatus.fromBook(newBook)
+
+        this.logger.debug("book's new state is {}", status)
+        this.bookRegistry.update(BookWithStatus(newBook, status))
+      }
+      else {
+        dbEntry.writeOPDSEntry(entry.feedEntry)
+        val newBook = dbEntry.book.copy(formats = emptyList())
+        val status = BookStatus.fromBook(newBook)
+
+        this.logger.debug("book's new state is {}", status)
+        this.bookRegistry.update(BookWithStatus(newBook, status))
+      }
     } else {
       throw IOException("No alternate link is available")
     }

--- a/simplified-feeds-api/src/main/java/org/nypl/simplified/feeds/api/FeedLoading.kt
+++ b/simplified-feeds-api/src/main/java/org/nypl/simplified/feeds/api/FeedLoading.kt
@@ -35,7 +35,7 @@ object FeedLoading {
     uri: URI,
     timeout: Pair<Long, TimeUnit>,
     method: String = "GET"
-  ): FeedEntryOPDS {
+  ): FeedEntryOPDS? {
     taskRecorder.beginNewStep("Fetching OPDS feed...")
 
     val feedResult =
@@ -52,8 +52,8 @@ object FeedLoading {
         throw feedResult.exception
       }
       is FeedLoaderFailedGeneral -> {
-        taskRecorder.currentStepFailed(feedResult.message, "feedFailed", feedResult.exception)
-        throw feedResult.exception
+        //If the loading fails, return null since the book is going to get deleted anyway
+        null
       }
       is FeedLoaderSuccess -> {
         taskRecorder.currentStepSucceeded("Feed retrieved and parsed.")

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookAvailabilityStrings.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookAvailabilityStrings.kt
@@ -146,6 +146,10 @@ object CatalogBookAvailabilityStrings {
       val queue = queueLengthOpt.get()
       val copiesAvailable = copiesAvailableOpt.get()
       val copiesTotal = copiesTotalOpt.get()
+      //If there are 0 copiesTotal, show that book is not available
+      if (copiesTotal == 0) {
+        return resources.getString(R.string.catalogBookAvailabilityNotAvailable)
+      }
       return resources.getString(R.string.catalogBookAvailabilityHoldableFull, queue, copiesAvailable, copiesTotal)
     }
     //Otherwise show a generic message

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -912,6 +912,17 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
   ) {
     this.buttons.removeAllViews()
 
+      if (bookStatus.copiesTotal == 0) {
+        //If we don't have any copies, we have run out of licenses, and should not show any buttons
+        // but show info text informing of this
+        this.statusInProgress.visibility = View.INVISIBLE
+        this.statusIdle.visibility = View.VISIBLE
+        this.statusFailed.visibility = View.INVISIBLE
+        this.statusIdleText.text =
+          CatalogBookAvailabilityStrings.statusString(this.resources, bookStatus)
+        return
+      }
+
     this.buttons.addView(
       this.buttonCreator.createReserveButton(
         onClick = {

--- a/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
@@ -35,6 +35,7 @@
   <string name="catalogBookAvailabilityHeldReadyIndefinite">This book is available to borrow.</string>
   <string name="catalogBookAvailabilityHoldable">This book is available to place on hold.</string>
   <string name="catalogBookAvailabilityHoldableFull">This book is available to place on hold. \nHold queue: %1$d, available: %2$d/%3$d</string>
+    <string name="catalogBookAvailabilityNotAvailable">This book is unavailable.</string>
   <string name="catalogBookAvailabilityLoanable">This book is available to borrow.</string>
   <string name="catalogBookAvailabilityLoanableFull">This book is available to borrow. \nAvailable: %1$d/%2$d</string>
   <string name="catalogBookAvailabilityLoanedIndefinite">You have this book on loan.</string>


### PR DESCRIPTION
**What's this do?**

This pr adds handling of 404 answers from the server to revoking books. 404 shows up when the revoke has actually been progressed correctly, and there is no longer a loan/hold.

Since the server returns 404, the app considers it as an error, so it doesn't get removed from the database. 

Here we add the handling of 404 errors to revoking books, as well as the book sync, that attempts to return old books that are no longer present in the loans feed.

Now, instead of failing, we instead build a new entry based on the entry we already have in the database, but we replace the availability information with holdable info, with values of 0 for queue, available copies and copies total.

If a book has 0 copies total, we remove all the buttons, and show a text of this book is unavailable.

**Why are we doing this? (w/ JIRA link if applicable)**
This is done because books that we don't have licenses anymore remain hanging in the loans and holds of users.

[EKIRJASTO-767](https://jira.it.helsinki.fi/browse/EKIRJASTO-767)

**How should this be tested? / Do these changes have associated tests?**
This can be tested by connecting android to local backend, and changing a books checkouts_available to 1 to emulate the situation of taking the last book to loan. Returning this book should first cause error, (server returns 403 but this is changed in a soon to be published circulation update). When trying again, the server should return 404, but the app should handle it correctly, and the loan should get removed, and if the return is done from the one book view, the buttons should dissapear and the text should say that the book is unavailable.

the book sync handling is more difficult to test, I did not do this either. You should take a book on loan like in the previous situation, but wait until the loan time runs out, and then refresh the feed. The book should be removed like in the previous case.

**Did someone actually run this code to verify it works?**
Tested on emulator(API 35), connected to local backend.

**Does this require updates to old Transifex strings? Have the translators been informed?**
New string has been added. Translations will be added, no translators have been informed since it's a simple translation.
**AI was used during the process and I have described above how.**
No use of AI.

- [ ] AI was used during the process and I have described above how.
