### PR TITLE
Add Ruby 3.2 setup with Bundler to CI workflow

### DIFF
--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -34,6 +34,13 @@ jobs:
           distribution: 'zulu'
           java-version: 17
 
+      - name: Set up Ruby and Bundler
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: simplified-app-ekirjasto
+
       - name: Reveal secrets
         env:
           EKIRJASTO_LOCAL_PROPERTIES_BASE64: ${{ secrets.LOCAL_PROPERTIES }}


### PR DESCRIPTION
**What's this do?**
This adds a step to the GitHub actions workflow to set up ruby and bundler for the `simplified-app-ekirjasto` directory. This should make sure that the correct ruby env is available during workflow run.
