### PR TITLE
EKIR-895 Bump the targetSDK version to 36

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,8 @@ org.gradle.configuration-cache-problems=warn
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.parallel=true
 
-org.thepalaceproject.build.androidSDKCompile=35
-org.thepalaceproject.build.androidSDKTarget=35
+org.thepalaceproject.build.androidSDKCompile=36
+org.thepalaceproject.build.androidSDKTarget=36
 org.thepalaceproject.build.androidSDKMinimum=24
 org.thepalaceproject.build.checkSemanticVersioning=false
 org.thepalaceproject.build.enableKtLint=false


### PR DESCRIPTION
**What's this do?**
This pr bumps the targetSDK version to 36, as it is required for keeping the app in Google Store.

The bump changes the following: 
Edge-to-edge is mandatory (no more opt-out) - this is done previously
onBackPressed() is dead - tested, and our backspace works correctly, using OnBackPressedDispatcher, but Android studio notes some of the implementations to be  deprecated
Tablets ignore your orientation locks (sw600dp+ devices) - we have fixed this previously, lock is not in use
16KB page size support required by Nov 2025 - implemented

**Why are we doing this? (w/ JIRA link if applicable)**
We do this to ensure our app remains in the store

[EKIRJASTO-895](https://jira.it.helsinki.fi/browse/EKIRJASTO-895)

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]

All actions user takes should work, app should behave as it did previously. 

**Did someone actually run this code to verify it works?**

Ran on emulators with API 25, and a tablet with API 27 (the tablet complains about the page size, but it does not affect the behaviour, and Saku said it to be okay, most likely gets fixed with the readium update)


**Does this require updates to old Transifex strings? Have the translators been informed?**
No new translations.
**AI was used during the process and I have described above how.**
No AI used.
- [ ] AI was used during the process and I have described above how.
