### PR TITLE
Configure bundler settings in android-release.yml

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -33,6 +33,11 @@ jobs:
           distribution: 'zulu'
           java-version: 17
 
+      - name: Configure bundler for CI
+        run: |
+          bundle config set cache_path /tmp/bundle_cache
+          bundle config set path vendor/bundle
+        
       - name: Reveal secrets
         env:
           EKIRJASTO_LOCAL_PROPERTIES_BASE64: ${{ secrets.LOCAL_PROPERTIES }}


### PR DESCRIPTION
Add bundler configuration for CI 

**What's this do?**
This pull set bundler cache dir to prevent permission errors.

